### PR TITLE
replacing cancellation exception rethrows

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,9 @@
 * beep sound playback for countdown is not very well synced with timer. Check [audio latency](https://developer.android.com/ndk/guides/audio/audio-latency) [check this example](https://github.com/o4oren/android-kotlin-metronome/blob/master/app/src/main/java/geva/oren/android_kotlin_metronome/services/MetronomeService.kt), using [Soundpool](https://developer.android.com/reference/android/media/SoundPool?hl=en)
 * SessionErrorStateContent is empty
 * replace toggle buttons' design with the one with a toggle check from Material, to make it more clear for the user
+* design for statistics needs some love
+* design for session summary needs some love
+* create a About section, in which to add credits for PoseMy.Art
 
 ## Code refactoring: layouts
 * Fix layouts composition:
@@ -17,14 +20,12 @@
 * once split into modules, add inter-modules dependencies graph generator plugin:
   * classpath "com.vanniktech:gradle-dependency-graph-generator-plugin:0.8.0"
   * apply plugin: "com.vanniktech.dependency.graph.generator"
-* split off the statistics section as a feature module to experiment with optional feature management as android module
 * check this about [replacing sealed classes with interfaces](https://jorgecastillo.dev/sealed-interfaces-kotlin)
 * check [this about reducing amount of code](https://kotlinlang.org/docs/fun-interfaces.html#sam-conversions), using [the invoke operator](https://chrynan.codes/invoking-usecases-the-kotlin-way/)
+* wrap usecases in _interactors_ objects to reduce number of parameters in `viewmodels`' constructors
 
 ## Assets production
-* create GIFs for exercises with https://app.posemy.art/ (start by listing all the ones we have, then compose steps, probably 2 per exercises and export, then make gifs from that with Photoshop) _remember that exercises from the same family might often use the same base position_
-* when making pictures for GIFS, insert watermark "@SimpleHIIT by Shining-cat" on body for each one
-* refine statistics cards design and find icons for each
+* refine statistics cards design and find/create icons for each
   * longest streak: icon of a cup and a calendar showing checked days
   * current streak: icon of a calendar showing checked days - IF current streak == longest, switch to same icon as longest streak to make it more clear
   * average session length: icon of the app above a clock
@@ -33,10 +34,10 @@
   * total sessions count: laurels crown
 
 ## General technical improvements
-* replace [CancellationException rethrows with coroutineContext.ensureActive](https://betterprogramming.pub/the-silent-killer-thats-crashing-your-coroutines-9171d1e8f79b)
 * check what this flooding error is and fix if possible: _Attempt to update InputPolicyFlags without permission ACCESS_SURFACE_FLINGER_
-* check out remember for state in composables and implement
-* write tests on Viewmodels, maybe extract some more logic out of them
+* check out `remember` for state in composables and implement
+* extract all that can still be from `viewmodels` to usecases
+* write tests on `Viewmodels`
 * fix test coverage task for instrumented tests not reporting any coverage. use dedicated simplified project jacoco_exp to investigate
 * switch to [version catalog for gradle dependencies](https://proandroiddev.com/mastering-gradle-dependency-management-with-version-catalogs-a-comprehensive-guide-d60e2fd1dac2)
 * CI github actions: run tests + linter (KTlint) before merge,[see article](https://medium.com/geekculture/how-to-build-sign-and-publish-android-application-using-github-actions-aa6346679254) or[ this one](https://proandroiddev.com/create-android-release-using-github-actions-c052006f6b0b?source=rss----c72404660798---4)
@@ -56,6 +57,5 @@
 ## Discuss with others
 * How to handle building the different app form factors, maybe[ flavours and buildtypes?](https://blog.protein.tech/product-flavors-and-build-types-in-android-projects-customizing-base-urls-logos-and-more-bf0099508949?source=rss------android_development-5)
 * See SimpleHiitDataStoreManagerImplTest -> how to trigger throwing exception from test dataStore?
-* discuss filtering out CancellationException: how relevant is it to do it multiple times in a flow of data
 
 

--- a/app/src/main/java/fr/shining_cat/simplehiit/data/local/datastore/SimpleHiitDataStoreManagerImpl.kt
+++ b/app/src/main/java/fr/shining_cat/simplehiit/data/local/datastore/SimpleHiitDataStoreManagerImpl.kt
@@ -114,7 +114,6 @@ class SimpleHiitDataStoreManagerImpl(
         dataStore.data.catch { exception ->
             // dataStore.data throws an IOException when an error is encountered when reading data
             hiitLogger.e("SimpleHiitDataStoreManager", "getPreferences - swallowing exception, clearing whole datastore and returning default values:: $exception")
-           //TODO: should we also filter out CancellationException to avoid blocking the natural handling of cancellation by the coroutine flow
             clearAll()
             SimpleHiitPreferences()
         }.map { preferences ->

--- a/app/src/main/java/fr/shining_cat/simplehiit/ui/components/GifImage.kt
+++ b/app/src/main/java/fr/shining_cat/simplehiit/ui/components/GifImage.kt
@@ -44,9 +44,11 @@ fun GifImage(
     }
     Image(
         painter = rememberAsyncImagePainter(
-            ImageRequest.Builder(context).data(data = gifResId).apply(block = {
-                size(Size.ORIGINAL)
-            }).build(), imageLoader = imageLoader
+            model = ImageRequest.Builder(context)
+                .data(data = gifResId)
+                .apply(block = {size(Size.ORIGINAL)})
+                .build(),
+            imageLoader = imageLoader
         ),
         contentDescription = null,
         modifier = imageModifier.fillMaxWidth(),

--- a/app/src/test/java/fr/shining_cat/simplehiit/data/SimpleHiitRepositoryImplDeleteAllUsersTest.kt
+++ b/app/src/test/java/fr/shining_cat/simplehiit/data/SimpleHiitRepositoryImplDeleteAllUsersTest.kt
@@ -60,30 +60,6 @@ internal class SimpleHiitRepositoryImplDeleteAllUsersTest : AbstractMockkTest() 
     }
 
     @Test
-    fun `delete all users rethrows CancellationException when usersDao delete all users throws CancellationException`() =
-        runTest {
-            val simpleHiitRepository = SimpleHiitRepositoryImpl(
-                usersDao = mockUsersDao,
-                sessionRecordsDao = mockSessionRecordsDao,
-                userMapper = mockUserMapper,
-                sessionMapper = mockSessionMapper,
-                hiitDataStoreManager = mockSimpleHiitDataStoreManager,
-                hiitLogger = mockHiitLogger,
-                ioDispatcher = UnconfinedTestDispatcher(testScheduler)
-            )
-            //
-            val thrownCancellationException = CancellationException()
-            coEvery { mockUsersDao.deleteAllUsers() } throws thrownCancellationException
-            //
-            assertThrows<CancellationException> {
-                simpleHiitRepository.deleteAllUsers()
-            }
-            //
-            coVerify(exactly = 1) { mockUsersDao.deleteAllUsers() }
-            coVerify(exactly = 1) { mockHiitLogger.e(any(), any(), thrownCancellationException) }
-        }
-
-    @Test
     fun `delete all user returns nothing when usersDao delete all users succeeds`() = runTest {
         val simpleHiitRepository = SimpleHiitRepositoryImpl(
             usersDao = mockUsersDao,

--- a/app/src/test/java/fr/shining_cat/simplehiit/data/SimpleHiitRepositoryImplDeleteSessionsForUserTest.kt
+++ b/app/src/test/java/fr/shining_cat/simplehiit/data/SimpleHiitRepositoryImplDeleteSessionsForUserTest.kt
@@ -8,11 +8,18 @@ import fr.shining_cat.simplehiit.data.mappers.SessionMapper
 import fr.shining_cat.simplehiit.data.mappers.UserMapper
 import fr.shining_cat.simplehiit.domain.Constants
 import fr.shining_cat.simplehiit.domain.Output
+import io.mockk.FunctionAnswer
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -63,7 +70,7 @@ internal class SimpleHiitRepositoryImplDeleteSessionsForUserTest : AbstractMockk
     }
 
     @Test
-    fun `delete sessions for user rethrows CancellationException when sessionsDao delete throws CancellationException`() =
+    fun `delete sessions for user throws CancellationException when job is cancelled`() =
         runTest {
             val simpleHiitRepository = SimpleHiitRepositoryImpl(
                 usersDao = mockUsersDao,
@@ -75,14 +82,51 @@ internal class SimpleHiitRepositoryImplDeleteSessionsForUserTest : AbstractMockk
                 ioDispatcher = UnconfinedTestDispatcher(testScheduler)
             )
             //
-            coEvery { mockSessionRecordsDao.deleteForUser(any()) } throws mockk<CancellationException>()
-            //
-            assertThrows<CancellationException> {
-                simpleHiitRepository.deleteSessionRecordsForUser(testUserId)
+            coEvery { mockSessionRecordsDao.deleteForUser(any()) } coAnswers {
+                println("inserting delay in DAO call to allow for job cancellation before result is returned")
+                delay(100L)
+                2
             }
+            //
+            val job = Job()
+            launch(job){
+                assertThrows<CancellationException> {
+                    simpleHiitRepository.deleteSessionRecordsForUser(testUserId)
+                }
+            }
+            delay(50L)
+            println("canceling job")
+            job.cancelAndJoin()
             //
             coVerify(exactly = 1) { mockSessionRecordsDao.deleteForUser(testUserId) }
             coVerify(exactly = 0) { mockHiitLogger.e(any(), any(), any()) }
+        }
+
+    @Test
+    fun `delete sessions for user catches rogue CancellationException`() =
+        runTest {
+            val simpleHiitRepository = SimpleHiitRepositoryImpl(
+                usersDao = mockUsersDao,
+                sessionRecordsDao = mockSessionRecordsDao,
+                userMapper = mockUserMapper,
+                sessionMapper = mockSessionMapper,
+                hiitDataStoreManager = mockSimpleHiitDataStoreManager,
+                hiitLogger = mockHiitLogger,
+                ioDispatcher = UnconfinedTestDispatcher(testScheduler)
+            )
+            //
+            val thrownException = CancellationException()
+            coEvery { mockSessionRecordsDao.deleteForUser(any()) } throws thrownException
+            //
+            val actual = simpleHiitRepository.deleteSessionRecordsForUser(testUserId)
+            //
+            coVerify(exactly = 1) { mockSessionRecordsDao.deleteForUser(testUserId) }
+            coVerify(exactly = 1) { mockHiitLogger.e(any(), any(), thrownException) }
+            val expectedOutput = Output.Error(
+                errorCode = Constants.Errors.DATABASE_DELETE_FAILED,
+                exception = thrownException
+            )
+            assertEquals(expectedOutput, actual)
         }
 
     @ParameterizedTest(name = "{index} -> when DAO update user returns {0} should return success with delete count")

--- a/app/src/test/java/fr/shining_cat/simplehiit/data/SimpleHiitRepositoryImplGetUsersTest.kt
+++ b/app/src/test/java/fr/shining_cat/simplehiit/data/SimpleHiitRepositoryImplGetUsersTest.kt
@@ -176,29 +176,6 @@ internal class SimpleHiitRepositoryImplGetUsersTest : AbstractMockkTest() {
         collectJob.cancel()
     }
 
-    @Test
-    fun `get users rethrows CancellationException when it gets thrown`() = runTest {
-        val simpleHiitRepository = SimpleHiitRepositoryImpl(
-            usersDao = mockUsersDao,
-            sessionRecordsDao = mockSessionRecordsDao,
-            userMapper = mockUserMapper,
-            sessionMapper = mockSessionMapper,
-            hiitDataStoreManager = mockSimpleHiitDataStoreManager,
-            hiitLogger = mockHiitLogger,
-            ioDispatcher = UnconfinedTestDispatcher(testScheduler)
-        )
-        //
-        coEvery { mockUsersDao.getUsers() } throws mockk<CancellationException>()
-        //
-        assertThrows<CancellationException> {
-            simpleHiitRepository.getUsers()
-        }
-        //
-        coVerify(exactly = 1) { mockUsersDao.getUsers() }
-        coVerify(exactly = 0) { mockUserMapper.convert(any<UserEntity>()) }
-        coVerify(exactly = 0) { mockHiitLogger.e(any(), any(), any()) }
-    }
-
 //////////////
 //   GET SELECTED USERS
 
@@ -334,29 +311,6 @@ internal class SimpleHiitRepositoryImplGetUsersTest : AbstractMockkTest() {
         )
         assertEquals(expectedOutput, result)
         collectJob.cancel()
-    }
-
-    @Test
-    fun `get selected users rethrows CancellationException when it gets thrown`() = runTest {
-        val simpleHiitRepository = SimpleHiitRepositoryImpl(
-            usersDao = mockUsersDao,
-            sessionRecordsDao = mockSessionRecordsDao,
-            userMapper = mockUserMapper,
-            sessionMapper = mockSessionMapper,
-            hiitDataStoreManager = mockSimpleHiitDataStoreManager,
-            hiitLogger = mockHiitLogger,
-            ioDispatcher = UnconfinedTestDispatcher(testScheduler)
-        )
-        //
-        coEvery { mockUsersDao.getSelectedUsers() } throws mockk<CancellationException>()
-        //
-        assertThrows<CancellationException> {
-            simpleHiitRepository.getSelectedUsers()
-        }
-        //
-        coVerify(exactly = 1) { mockUsersDao.getSelectedUsers() }
-        coVerify(exactly = 0) { mockUserMapper.convert(any<UserEntity>()) }
-        coVerify(exactly = 0) { mockHiitLogger.e(any(), any(), any()) }
     }
 
     ////////////////////////

--- a/app/src/test/java/fr/shining_cat/simplehiit/data/SimpleHiitRepositoryImplSettingsTest.kt
+++ b/app/src/test/java/fr/shining_cat/simplehiit/data/SimpleHiitRepositoryImplSettingsTest.kt
@@ -322,28 +322,6 @@ internal class SimpleHiitRepositoryImplSettingsTest : AbstractMockkTest() {
         collectJob.cancel()
     }
 
-    @Test
-    fun `getGeneralSettings rethrows CancellationException when it gets thrown by datastore`() =
-        runTest {
-            val simpleHiitRepository = SimpleHiitRepositoryImpl(
-                usersDao = mockUsersDao,
-                sessionRecordsDao = mockSessionRecordsDao,
-                userMapper = mockUserMapper,
-                sessionMapper = mockSessionMapper,
-                hiitDataStoreManager = mockSimpleHiitDataStoreManager,
-                hiitLogger = mockHiitLogger,
-                ioDispatcher = UnconfinedTestDispatcher(testScheduler)
-            )
-            //
-            coEvery { mockSimpleHiitDataStoreManager.getPreferences() } throws mockk<CancellationException>()
-            //
-            assertThrows<CancellationException> {
-                simpleHiitRepository.getPreferences()
-            }
-            coVerify(exactly = 1) { mockSimpleHiitDataStoreManager.getPreferences() }
-            coVerify(exactly = 0) { mockHiitLogger.e(any(), any(), any()) }
-        }
-
 //////////////////
 
     @Test


### PR DESCRIPTION
replaced CancellationException rethrows with coroutineContext.ensureActive as per (https://betterprogramming.pub/the-silent-killer-thats-crashing-your-coroutines-9171d1e8f79b)
removed irrelevant specific CancellationException handling in the case of Flows in non-suspending methods
adapted tests to check for both catching rogue CancellationException, and checking that real job cancellation causes a CancellationException to be thrown
small formatting in GifImage
updated todo