### PR TITLE
Fix countdown beep sound latency

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,14 +1,8 @@
 # SimpleHIIT ToDo list
 
 ## Missing features / issues
-* had to exclude the external instrumented tests module from report aggregation plugin, see testAggregation block in build.gradle. [discussion ongoing with author...](https://github.com/gmazzo/gradle-android-test-aggregation-plugin/issues/32)
-* find a way to fix resolution issue when adding `id("com.google.dagger.hilt.android")` to `libraries_gradle_config`, to remove it from every module and apply it from the plugin
-* beep sound playback for countdown is not very well synced with timer. Check [audio latency](https://developer.android.com/ndk/guides/audio/audio-latency), and [check this example](https://github.com/o4oren/android-kotlin-metronome/blob/master/app/src/main/java/geva/oren/android_kotlin_metronome/services/MetronomeService.kt), using [Soundpool](https://developer.android.com/reference/android/media/SoundPool?hl=en)
+* we need to pause the session in onResume equivalent (then, when coming back the state will be paused with dialog open so we should need nothing for the "coming back" part)
 * SessionErrorStateContent is empty
-* replace toggle buttons' design with the one with a toggle check from Material, to make it more clear for the user
-* design for statistics needs some love
-* design for session summary needs some love
-* create a About section, in which to add credits for PoseMy.Art
 
 ## Code refactoring: layouts
 * Fix layouts composition:
@@ -17,7 +11,8 @@
 * fix broken layout in landscape
 
 ## Code refactoring: architecture
-* 
+* find a way to fix resolution issue when adding `id("com.google.dagger.hilt.android")` to `libraries_gradle_config`, to remove it from every module and apply it from the plugin
+* remove the NavController parameter in the screens, [as per this answer](https://stackoverflow.com/a/69060224/3585796), only pass lambdas down
 
 ## Assets production
 * refine statistics cards design and find/create icons for each
@@ -29,7 +24,10 @@
   * total sessions count: laurels crown
 
 ## General technical improvements
-* check out `remember` for state in composables and implement
+* remove the NavController parameter in the screens, [as per this answer](https://stackoverflow.com/a/69060224/3585796), only pass lambdas down
+* find a way to fix resolution issue when adding `id("com.google.dagger.hilt.android")` to `libraries_gradle_config`, to remove it from every module and apply it from the plugin
+* optimize composition trees by checking where state hoisting could be leveraged and various states level down the tree eventually remembered -> **NON-CRITICAL** as we already have all the state hoisting moved to the ViewModels.
+* had to exclude the external instrumented tests module from report aggregation plugin, see testAggregation block in build.gradle. [ongoing discussion with author...](https://github.com/gmazzo/gradle-android-test-aggregation-plugin/issues/32)
 * fix test coverage task for instrumented tests not reporting any coverage. use dedicated simplified project jacoco_exp to investigate
 * switch to [version catalog for gradle dependencies](https://proandroiddev.com/mastering-gradle-dependency-management-with-version-catalogs-a-comprehensive-guide-d60e2fd1dac2)
 * check out [this article about including the inter-modules dependencies graph generation to the CI](https://medium.com/google-developer-experts/how-to-display-your-android-project-dependency-graph-in-your-readme-file-e52dcadafa7a)
@@ -43,7 +41,11 @@
 
 ## Miscellaneous / nice to have
 * instead of a dialog for the total number of repetitions see if a + and - buttons wouldn't be better
+* replace toggle buttons' design with the one with a toggle check from Material, to make it more clear for the user
 * add total length of session below the number of repetitions so user knows how long it will last
+* design for statistics needs some love
+* design for session summary needs some love
+* create a _About_ section, in which to add credits for PoseMy.Art
 * when pausing running session, the gif behind the dialog keeps moving... find a way to freeze this if possible
 * translate to FR and SV. Maybe add language selection in settings to be able to demo it?
 * we follow system dark/light theme switch, maybe we could add a choice in settings to let user decide? (follow system (would be default), force dark, force light)

--- a/android/mobile/ui/home/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/home/HomeScreen.kt
+++ b/android/mobile/ui/home/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/home/HomeScreen.kt
@@ -43,7 +43,6 @@ fun HomeScreen(
     hiitLogger: HiitLogger,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
-    hiitLogger.d("HomeScreen", "INIT")
     val durationsFormatter = DurationStringFormatter(
         hoursMinutesSeconds = stringResource(id = R.string.hours_minutes_seconds_short),
         hoursMinutesNoSeconds = stringResource(id = R.string.hours_minutes_no_seconds_short),

--- a/android/mobile/ui/home/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/home/HomeViewModel.kt
+++ b/android/mobile/ui/home/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/home/HomeViewModel.kt
@@ -44,7 +44,6 @@ class HomeViewModel @Inject constructor(
     }
 
     fun cancelDialog() {
-        hiitLogger.d("HomeViewModel", "cancelDialog")
         viewModelScope.launch(context = mainDispatcher) {
             _dialogViewState.emit(HomeDialog.None)
         }

--- a/android/mobile/ui/session/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/session/components/CountDownComponent.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/session/components/CountDownComponent.kt
@@ -27,15 +27,15 @@ import fr.shining_cat.simplehiit.android.mobile.ui.session.CountDown
 import fr.shining_cat.simplehiit.commonutils.HiitLogger
 
 @Composable
-fun CountDownComponent(size: Dp, countDown: CountDown, hiitLogger: HiitLogger? = null) {
-    hiitLogger?.d("CountDownComponent", "INIT:${countDown.secondsDisplay}")
+fun CountDownComponent(
+    size: Dp,
+    countDown: CountDown,
+    hiitLogger: HiitLogger? = null
+) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier.size(size)
     ) {
-        if (countDown.playBeep) {
-            BeepPlayer(countDown = countDown, hiitLogger = hiitLogger)
-        }
         //this first never-moving one is to simulate the trackColor from a LinearProgressIndicator
         CircularProgressIndicator(
             modifier = Modifier
@@ -62,26 +62,7 @@ fun CountDownComponent(size: Dp, countDown: CountDown, hiitLogger: HiitLogger? =
     }
 }
 
-@Composable
-fun BeepPlayer(
-    countDown: CountDown,
-    lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
-    hiitLogger: HiitLogger? = null
-) {
-    hiitLogger?.d("BeepPlayer", "INIT:${countDown.secondsDisplay}")
-    val player = MediaPlayer.create(LocalContext.current, R.raw.sound_beep)
-    countDown.secondsDisplay.onEach {
-        player.start()
-    }
-    DisposableEffect(lifecycleOwner) {
-        onDispose {
-            player.release()
-        }
-    }
-}
-
 // Previews
-//TODO: Preview seems broken
 @Preview(
     showBackground = true,
     uiMode = Configuration.UI_MODE_NIGHT_NO

--- a/android/mobile/ui/session/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/session/contents/SessionPrepareContent.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/session/contents/SessionPrepareContent.kt
@@ -21,9 +21,12 @@ fun SessionPrepareContent(
     hiitLogger: HiitLogger? = null
 ) {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        CountDownComponent(size = 64.dp, countDown = viewState.countDown, hiitLogger = hiitLogger)
+        CountDownComponent(
+            size = 64.dp,
+            countDown = viewState.countDown,
+            hiitLogger = hiitLogger
+        )
     }
-
 }
 
 // Previews

--- a/android/mobile/ui/settings/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/settings/SettingsScreen.kt
+++ b/android/mobile/ui/settings/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/settings/SettingsScreen.kt
@@ -43,7 +43,6 @@ fun SettingsScreen(
     hiitLogger: HiitLogger,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
-    hiitLogger.d("SettingsScreen", "INIT")
     val durationsFormatter = DurationStringFormatter(
         hoursMinutesSeconds = stringResource(id = R.string.hours_minutes_seconds_short),
         hoursMinutesNoSeconds = stringResource(id = R.string.hours_minutes_no_seconds_short),

--- a/android/mobile/ui/statistics/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/statistics/StatisticsScreen.kt
+++ b/android/mobile/ui/statistics/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/statistics/StatisticsScreen.kt
@@ -37,7 +37,6 @@ fun StatisticsScreen(
     hiitLogger: HiitLogger,
     viewModel: StatisticsViewModel = hiltViewModel()
 ) {
-    hiitLogger.d("StatisticsScreen", "INIT")
     //
     val durationsFormatter = DurationStringFormatter(
         hoursMinutesSeconds = stringResource(id = R.string.hours_minutes_seconds_short),

--- a/domain/session/src/main/java/fr/shining_cat/simplehiit/domain/session/usecases/BuildSessionUseCase.kt
+++ b/domain/session/src/main/java/fr/shining_cat/simplehiit/domain/session/usecases/BuildSessionUseCase.kt
@@ -81,7 +81,7 @@ class BuildSessionUseCase @Inject constructor(
                 allSteps.add(prepareStep)
             }
             for ((index, exercise) in exercisesList.withIndex()) {
-                hiitLogger.d("BuildSessionUseCase", "buildStepsList::index = $index")
+//                hiitLogger.d("BuildSessionUseCase", "buildStepsList::index = $index")
                 //we're not checking the asymmetrical attribute here as it has already been taking into consideration while building this exercisesList by adding asymmetrical exercises twice.
                 val stepExerciseSide = when (exercise) {
                     exercisesList.getOrNull(index - 1) -> {//if previous exercise was the same, then we are handling an asymmetrical for the second side
@@ -98,10 +98,7 @@ class BuildSessionUseCase @Inject constructor(
                 }
                 //
                 val remainingExercisesAfterStep = totalSteps.minus(index).minus(1)
-                hiitLogger.d(
-                    "BuildSessionUseCase",
-                    "buildStepsList::remainingExercises = $remainingExercisesAfterStep"
-                )
+//                hiitLogger.d("BuildSessionUseCase","buildStepsList::remainingExercises = $remainingExercisesAfterStep")
                 val restStepDurationFormatted =
                     formatLongDurationMsAsSmallestHhMmSsStringUseCase.execute(
                         restPeriodLengthMs,
@@ -116,16 +113,10 @@ class BuildSessionUseCase @Inject constructor(
                     (remainingExercisesAfterStep.plus(1)).times(workPeriodLengthMs) + (remainingExercisesAfterStep).times(
                         restPeriodLengthMs
                     )
-                hiitLogger.d(
-                    "BuildSessionUseCase",
-                    "buildStepsList::remainingSessionDurationMsAfterRest = $remainingSessionDurationMsAfterRest"
-                )
+//                hiitLogger.d("BuildSessionUseCase","buildStepsList::remainingSessionDurationMsAfterRest = $remainingSessionDurationMsAfterRest")
                 val remainingSessionDurationMsAfterWork =
                     remainingExercisesAfterStep.times(workPeriodLengthMs.plus(restPeriodLengthMs))
-                hiitLogger.d(
-                    "BuildSessionUseCase",
-                    "buildStepsList::remainingSessionDurationMsAfterWork = $remainingSessionDurationMsAfterWork"
-                )
+//                hiitLogger.d("BuildSessionUseCase","buildStepsList::remainingSessionDurationMsAfterWork = $remainingSessionDurationMsAfterWork")
                 //
                 val restStep = SessionStep.RestStep(
                     exercise = exercise,

--- a/domain/statistics/src/main/java/fr/shining_cat/simplehiit/domain/statistics/usecases/CalculateCurrentStreakUseCase.kt
+++ b/domain/statistics/src/main/java/fr/shining_cat/simplehiit/domain/statistics/usecases/CalculateCurrentStreakUseCase.kt
@@ -27,10 +27,6 @@ class CalculateCurrentStreakUseCase @Inject constructor(
                 val timeStamp2 = sortedTimestampsFromLast[index + 1]
                 val areConsecutiveDaysOrLess =
                     consecutiveDaysOrCloserUseCase.execute(timestamp, timeStamp2)
-                simpleHiitLogger.d(
-                    "CalculateCurrentStreakUseCase",
-                    "execute::areConsecutiveDaysOrLess = $areConsecutiveDaysOrLess"
-                )
                 when (areConsecutiveDaysOrLess) {
                     Consecutiveness.SAME_DAY -> {
                         if (index == 0) {

--- a/domain/statistics/src/main/java/fr/shining_cat/simplehiit/domain/statistics/usecases/CalculateLongestStreakUseCase.kt
+++ b/domain/statistics/src/main/java/fr/shining_cat/simplehiit/domain/statistics/usecases/CalculateLongestStreakUseCase.kt
@@ -24,10 +24,6 @@ class CalculateLongestStreakUseCase @Inject constructor(
                 val timeStamp2 = sortedTimestampsFromLast[index + 1]
                 val areConsecutiveDaysOrLess =
                     consecutiveDaysOrCloserUseCase.execute(timestamp, timeStamp2)
-                simpleHiitLogger.d(
-                    "CalculateCurrentStreakUseCase",
-                    "execute::areConsecutiveDaysOrLess = $areConsecutiveDaysOrLess"
-                )
                 when (areConsecutiveDaysOrLess) {
                     Consecutiveness.SAME_DAY -> {
                         if (index == 0) {

--- a/domain/statistics/src/main/java/fr/shining_cat/simplehiit/domain/statistics/usecases/ConsecutiveDaysOrCloserUseCase.kt
+++ b/domain/statistics/src/main/java/fr/shining_cat/simplehiit/domain/statistics/usecases/ConsecutiveDaysOrCloserUseCase.kt
@@ -48,11 +48,6 @@ class ConsecutiveDaysOrCloserUseCase @Inject constructor(
                 lateTimestampCal.timeInMillis = maxOf(timeStamp1, timeStamp2)
                 val lateAtMidnight = setTimePartOfDateToMidnight(lateTimestampCal)
                 val earlyAtMidnight = setTimePartOfDateToMidnight(earlyTimestampCal)
-                val result = TimeUnit.MILLISECONDS.toDays(lateAtMidnight - earlyAtMidnight).toInt()
-                hiitLogger.d(
-                    "ConsecutiveDaysOrCloserUseCase",
-                    "getNumberOfFullDaysBetween2Timestamps::result = $result"
-                )
                 TimeUnit.MILLISECONDS.toDays(lateAtMidnight - earlyAtMidnight).toInt()
             }
         }


### PR DESCRIPTION
play beep sound through a SoundPool to reduce latency. So far tests show a satisfying improvement.
Had to move the actual playing to the viewModel to actually benefit from the pooling, as having this in the composition tree killed the whole point by resetting it on every recomposition. Fixed some minor bugs in the session progression and navigating up from the preparation screen which was inconsistent between up and back button. Updated TODO
removed superfluous logs