### PR TITLE
fixed missing tests on SessionMapper

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 # SimpleHIIT ToDo list
 
 ## Missing features / issues
-* SessionMapper.buildStateWholeSession is not tested, SessionMapper.buildState is not used anymore
 
 ## Code refactoring: layouts
 * Fix layouts composition:

--- a/android/mobile/ui/home/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/home/HomeViewModel.kt
+++ b/android/mobile/ui/home/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/home/HomeViewModel.kt
@@ -17,7 +17,7 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val homeInteractor: HomeInteractor,
-    private val homeMapper: HomeMapper,
+    private val homeViewStateMapper: HomeViewStateMapper,
     @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
     private val hiitLogger: HiitLogger
 ) : ViewModel() {
@@ -35,7 +35,7 @@ class HomeViewModel @Inject constructor(
             viewModelScope.launch(context = mainDispatcher) {
                 homeInteractor.getHomeSettings().collect {
                     _screenViewState.emit(
-                        homeMapper.map(it, durationStringFormatter)
+                        homeViewStateMapper.map(it, durationStringFormatter)
                     )
                 }
             }

--- a/android/mobile/ui/home/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/home/HomeViewStateMapper.kt
+++ b/android/mobile/ui/home/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/home/HomeViewStateMapper.kt
@@ -1,17 +1,18 @@
 package fr.shining_cat.simplehiit.android.mobile.ui.home
 
+import fr.shining_cat.simplehiit.android.mobile.ui.home.HomeViewState.Error
+import fr.shining_cat.simplehiit.android.mobile.ui.home.HomeViewState.MissingUsers
+import fr.shining_cat.simplehiit.android.mobile.ui.home.HomeViewState.Nominal
+import fr.shining_cat.simplehiit.commonutils.HiitLogger
 import fr.shining_cat.simplehiit.domain.common.Output
 import fr.shining_cat.simplehiit.domain.common.models.DurationStringFormatter
 import fr.shining_cat.simplehiit.domain.common.models.HomeSettings
 import fr.shining_cat.simplehiit.domain.common.usecases.FormatLongDurationMsAsSmallestHhMmSsStringUseCase
-import fr.shining_cat.simplehiit.commonutils.HiitLogger
-import fr.shining_cat.simplehiit.android.mobile.ui.home.HomeViewState.Error
-import fr.shining_cat.simplehiit.android.mobile.ui.home.HomeViewState.MissingUsers
-import fr.shining_cat.simplehiit.android.mobile.ui.home.HomeViewState.Nominal
 import javax.inject.Inject
 
-class HomeMapper @Inject constructor(
+class HomeViewStateMapper @Inject constructor(
     private val formatLongDurationMsAsSmallestHhMmSsStringUseCase: FormatLongDurationMsAsSmallestHhMmSsStringUseCase,
+    @Suppress("unused")
     private val hiitLogger: HiitLogger
 ) {
 

--- a/android/mobile/ui/home/src/test/java/fr/shining_cat/simplehiit/android/mobile/ui/home/HomeViewStateMapperTest.kt
+++ b/android/mobile/ui/home/src/test/java/fr/shining_cat/simplehiit/android/mobile/ui/home/HomeViewStateMapperTest.kt
@@ -17,12 +17,12 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 
-internal class HomeMapperTest : AbstractMockkTest() {
+internal class HomeViewStateMapperTest : AbstractMockkTest() {
 
     private val mockFormatLongDurationMsAsSmallestHhMmSsStringUseCase =
         mockk<FormatLongDurationMsAsSmallestHhMmSsStringUseCase>()
     private val testedMapper =
-        HomeMapper(
+        HomeViewStateMapper(
             mockFormatLongDurationMsAsSmallestHhMmSsStringUseCase,
             mockHiitLogger
         )
@@ -41,7 +41,7 @@ internal class HomeMapperTest : AbstractMockkTest() {
     @MethodSource("homeSettingsArguments")
     fun `mapping homeSettings to correct viewstate`(
         input: Output<HomeSettings>,
-        expectedOutput: fr.shining_cat.simplehiit.android.mobile.ui.home.HomeViewState
+        expectedOutput: HomeViewState
     ) {
         val result = testedMapper.map(
             homeSettingsOutput = input,
@@ -83,7 +83,7 @@ internal class HomeMapperTest : AbstractMockkTest() {
                             users = listOf(testUser1, testUser3, testUser2, testUser4)
                         )
                     ),
-                    fr.shining_cat.simplehiit.android.mobile.ui.home.HomeViewState.Nominal(
+                    HomeViewState.Nominal(
                         numberCumulatedCycles = 3,
                         cycleLength = mockDurationString,
                         users = listOf(testUser1, testUser3, testUser2, testUser4)
@@ -97,7 +97,7 @@ internal class HomeMapperTest : AbstractMockkTest() {
                             users = listOf(testUser1, testUser2)
                         )
                     ),
-                    fr.shining_cat.simplehiit.android.mobile.ui.home.HomeViewState.Nominal(
+                    HomeViewState.Nominal(
                         numberCumulatedCycles = 5,
                         cycleLength = mockDurationString,
                         users = listOf(testUser1, testUser2)
@@ -111,7 +111,7 @@ internal class HomeMapperTest : AbstractMockkTest() {
                             users = listOf()
                         )
                     ),
-                    fr.shining_cat.simplehiit.android.mobile.ui.home.HomeViewState.MissingUsers(
+                    HomeViewState.MissingUsers(
                         numberCumulatedCycles = 3,
                         cycleLength = mockDurationString
                     )
@@ -121,14 +121,14 @@ internal class HomeMapperTest : AbstractMockkTest() {
                         errorCode = Constants.Errors.NO_USERS_FOUND,
                         exception = testException
                     ),
-                    fr.shining_cat.simplehiit.android.mobile.ui.home.HomeViewState.Error(Constants.Errors.NO_USERS_FOUND.code)
+                    HomeViewState.Error(Constants.Errors.NO_USERS_FOUND.code)
                 ),
                 Arguments.of(
                     Output.Error(
                         errorCode = Constants.Errors.DATABASE_FETCH_FAILED,
                         exception = testException
                     ),
-                    fr.shining_cat.simplehiit.android.mobile.ui.home.HomeViewState.Error(Constants.Errors.DATABASE_FETCH_FAILED.code)
+                    HomeViewState.Error(Constants.Errors.DATABASE_FETCH_FAILED.code)
                 )
             )
     }

--- a/android/mobile/ui/session/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/session/SessionViewModel.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/session/SessionViewModel.kt
@@ -26,7 +26,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SessionViewModel @Inject constructor(
     private val sessionInteractor: SessionInteractor,
-    private val mapper: SessionMapper,
+    private val mapper: SessionViewStateMapper,
     @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
     private val timeProvider: TimeProvider,
     private val hiitLogger: HiitLogger
@@ -180,7 +180,7 @@ class SessionViewModel @Inject constructor(
                     val currentState = mapper.buildStateWholeSession(
                         session = immutableSession,
                         currentSessionStepIndex = currentSessionStepIndex,
-                        currentState = stepTimerState,
+                        currentStepTimerState = stepTimerState,
                         durationStringFormatter = durationStringFormatter
                     )
                     maybePlayBeepSound(currentState = currentState)

--- a/android/mobile/ui/session/src/test/java/fr/shining_cat/simplehiit/android/mobile/ui/session/SessionViewStateMapperTest.kt
+++ b/android/mobile/ui/session/src/test/java/fr/shining_cat/simplehiit/android/mobile/ui/session/SessionViewStateMapperTest.kt
@@ -1,5 +1,6 @@
 package fr.shining_cat.simplehiit.android.mobile.ui.session
 
+import fr.shining_cat.simplehiit.android.mobile.ui.session.SessionViewState.InitialCountDownSession
 import fr.shining_cat.simplehiit.domain.common.models.AsymmetricalExerciseSideOrder
 import fr.shining_cat.simplehiit.domain.common.models.DurationStringFormatter
 import fr.shining_cat.simplehiit.domain.common.models.Exercise
@@ -10,7 +11,6 @@ import fr.shining_cat.simplehiit.domain.common.models.StepTimerState
 import fr.shining_cat.simplehiit.domain.common.models.User
 import fr.shining_cat.simplehiit.domain.common.usecases.FormatLongDurationMsAsSmallestHhMmSsStringUseCase
 import fr.shining_cat.simplehiit.testutils.AbstractMockkTest
-import fr.shining_cat.simplehiit.android.mobile.ui.session.SessionViewState.InitialCountDownSession
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 
 @OptIn(ExperimentalCoroutinesApi::class)
-internal class SessionMapperTest : AbstractMockkTest() {
+internal class SessionViewStateMapperTest : AbstractMockkTest() {
 
     private val mockFormatLongDurationMsAsSmallestHhMmSsStringUseCase =
         mockk<FormatLongDurationMsAsSmallestHhMmSsStringUseCase>()
@@ -55,13 +55,13 @@ internal class SessionMapperTest : AbstractMockkTest() {
         expectedViewStateOutput: SessionViewState
     ) = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
-        val testedMapper = SessionMapper(
+        val testedMapper = SessionViewStateMapper(
             formatLongDurationMsAsSmallestHhMmSsStringUseCase = mockFormatLongDurationMsAsSmallestHhMmSsStringUseCase,
             defaultDispatcher = testDispatcher,
             hiitLogger = mockHiitLogger
         )
         //
-        val result = testedMapper.buildState(
+        val result = testedMapper.buildStateWholeSession(
             session = sessionMapperTestParameter.session,
             currentSessionStepIndex = sessionMapperTestParameter.currentSessionStepIndex,
             currentStepTimerState = sessionMapperTestParameter.currentStepTimerState,
@@ -241,8 +241,8 @@ internal class SessionMapperTest : AbstractMockkTest() {
                         session = testSession,
                         currentSessionStepIndex = 0,
                         currentStepTimerState = StepTimerState(
-                            milliSecondsRemaining = 4,
-                            totalMilliSeconds = 5
+                            milliSecondsRemaining = 769000L,
+                            totalMilliSeconds = 800000L
                         )
                     ),
                     InitialCountDownSession(
@@ -259,8 +259,8 @@ internal class SessionMapperTest : AbstractMockkTest() {
                         session = testSession,
                         currentSessionStepIndex = 4,
                         currentStepTimerState = StepTimerState(
-                            milliSecondsRemaining = 10,
-                            totalMilliSeconds = 50
+                            milliSecondsRemaining = 605000L,
+                            totalMilliSeconds = 800000L
                         )
                     ),
                     SessionViewState.WorkNominal(
@@ -269,7 +269,7 @@ internal class SessionMapperTest : AbstractMockkTest() {
                         exerciseRemainingTime = mockDurationString, // verify formatter is called with 10000L,
                         exerciseRemainingPercentage = .2f,
                         sessionRemainingTime = mockDurationString, // verify formatter is called with (595000L + 10000L)
-                        sessionRemainingPercentage = .75625f, // (595000L + 10000L) / 800000L = 0.75625
+                        sessionRemainingPercentage = .75625f, // 605000L / 800000L = 0.75625
                         countDown = null
                     )
                 ),
@@ -279,8 +279,8 @@ internal class SessionMapperTest : AbstractMockkTest() {
                         session = testSession,
                         currentSessionStepIndex = 4,
                         currentStepTimerState = StepTimerState(
-                            milliSecondsRemaining = 1,
-                            totalMilliSeconds = 50
+                            milliSecondsRemaining = 596000L,
+                            totalMilliSeconds = 800000L
                         )
                     ),
                     SessionViewState.WorkNominal(
@@ -289,7 +289,7 @@ internal class SessionMapperTest : AbstractMockkTest() {
                         exerciseRemainingTime = mockDurationString, // verify formatter is called with 1000L,
                         exerciseRemainingPercentage = .02f,
                         sessionRemainingTime = mockDurationString, // verify formatter is called with (595000L + 1000L)
-                        sessionRemainingPercentage = .745f, // (595000L + 1000L) / 800000L =
+                        sessionRemainingPercentage = .745f, // 596000L / 800000L
                         countDown = CountDown(
                             secondsDisplay = "1",
                             progress = .2f, // 1/5 to float
@@ -303,8 +303,8 @@ internal class SessionMapperTest : AbstractMockkTest() {
                         session = testSession,
                         currentSessionStepIndex = 7,
                         currentStepTimerState = StepTimerState(
-                            milliSecondsRemaining = 7,
-                            totalMilliSeconds = 35
+                            milliSecondsRemaining = 482000L,
+                            totalMilliSeconds = 800000L
                         )
                     ),
                     SessionViewState.RestNominal(
@@ -313,7 +313,7 @@ internal class SessionMapperTest : AbstractMockkTest() {
                         restRemainingTime = mockDurationString, // verify formatter is called with 7000L,
                         restRemainingPercentage = .2f,
                         sessionRemainingTime = mockDurationString, // verify formatter is called with (475000L + 7000L)
-                        sessionRemainingPercentage = .6025f, // (475000L + 7000L) / 800000L = 0.75625
+                        sessionRemainingPercentage = .6025f, // 482000L / 800000L
                         countDown = null
                     )
                 ),
@@ -323,17 +323,17 @@ internal class SessionMapperTest : AbstractMockkTest() {
                         session = testSession,
                         currentSessionStepIndex = 7,
                         currentStepTimerState = StepTimerState(
-                            milliSecondsRemaining = 5,
-                            totalMilliSeconds = 50
+                            milliSecondsRemaining = 480000L,
+                            totalMilliSeconds = 800000L
                         )
                     ),
                     SessionViewState.RestNominal(
                         nextExercise = Exercise.PlankMountainClimber,
                         side = ExerciseSide.NONE,
                         restRemainingTime = mockDurationString, // verify formatter is called with 5000L,
-                        restRemainingPercentage = .1f,
+                        restRemainingPercentage = .14285715f,
                         sessionRemainingTime = mockDurationString, // verify formatter is called with (475000L + 5000L)
-                        sessionRemainingPercentage = .6f, // (475000L + 5000L) / 800000L =
+                        sessionRemainingPercentage = .6f, // 480000L / 800000L
                         countDown = CountDown(
                             secondsDisplay = "5",
                             progress = 1f, // 5/5 to float

--- a/android/mobile/ui/settings/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/settings/SettingsViewModel.kt
+++ b/android/mobile/ui/settings/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/settings/SettingsViewModel.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val settingsInteractor: SettingsInteractor,
-    private val mapper: SettingsMapper,
+    private val mapper: SettingsViewStateMapper,
     @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
     private val hiitLogger: HiitLogger
 ) : ViewModel() {

--- a/android/mobile/ui/settings/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/settings/SettingsViewStateMapper.kt
+++ b/android/mobile/ui/settings/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/settings/SettingsViewStateMapper.kt
@@ -1,17 +1,17 @@
 package fr.shining_cat.simplehiit.android.mobile.ui.settings
 
+import fr.shining_cat.simplehiit.android.mobile.ui.settings.SettingsViewState.Error
+import fr.shining_cat.simplehiit.android.mobile.ui.settings.SettingsViewState.Nominal
+import fr.shining_cat.simplehiit.commonutils.HiitLogger
 import fr.shining_cat.simplehiit.domain.common.Constants
 import fr.shining_cat.simplehiit.domain.common.Output
 import fr.shining_cat.simplehiit.domain.common.models.DurationStringFormatter
 import fr.shining_cat.simplehiit.domain.common.models.GeneralSettings
 import fr.shining_cat.simplehiit.domain.common.usecases.FormatLongDurationMsAsSmallestHhMmSsStringUseCase
-import fr.shining_cat.simplehiit.commonutils.HiitLogger
-import fr.shining_cat.simplehiit.android.mobile.ui.settings.SettingsViewState.Error
-import fr.shining_cat.simplehiit.android.mobile.ui.settings.SettingsViewState.Nominal
 import javax.inject.Inject
 import kotlin.math.roundToInt
 
-class SettingsMapper @Inject constructor(
+class SettingsViewStateMapper @Inject constructor(
     private val formatLongDurationMsAsSmallestHhMmSsStringUseCase: FormatLongDurationMsAsSmallestHhMmSsStringUseCase,
     private val hiitLogger: HiitLogger
 ) {

--- a/android/mobile/ui/settings/src/test/java/fr/shining_cat/simplehiit/android/mobile/ui/settings/SettingsViewStateMapperTest.kt
+++ b/android/mobile/ui/settings/src/test/java/fr/shining_cat/simplehiit/android/mobile/ui/settings/SettingsViewStateMapperTest.kt
@@ -19,11 +19,11 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 
-internal class SettingsMapperTest : AbstractMockkTest() {
+internal class SettingsViewStateMapperTest : AbstractMockkTest() {
 
     private val mockFormatLongDurationMsAsSmallestHhMmSsStringUseCase =
         mockk<FormatLongDurationMsAsSmallestHhMmSsStringUseCase>()
-    private val testedMapper = SettingsMapper(
+    private val testedMapper = SettingsViewStateMapper(
         formatLongDurationMsAsSmallestHhMmSsStringUseCase = mockFormatLongDurationMsAsSmallestHhMmSsStringUseCase,
         hiitLogger = mockHiitLogger
     )

--- a/android/mobile/ui/statistics/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/statistics/StatisticsViewModel.kt
+++ b/android/mobile/ui/statistics/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/statistics/StatisticsViewModel.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class StatisticsViewModel @Inject constructor(
     private val statisticsInteractor: StatisticsInteractor,
-    private val mapper: StatisticsMapper,
+    private val mapper: StatisticsViewStateMapper,
     @MainDispatcher private val mainDispatcher: CoroutineDispatcher,
     private val timeProvider: TimeProvider,
     private val hiitLogger: HiitLogger

--- a/android/mobile/ui/statistics/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/statistics/StatisticsViewStateMapper.kt
+++ b/android/mobile/ui/statistics/src/main/java/fr/shining_cat/simplehiit/android/mobile/ui/statistics/StatisticsViewStateMapper.kt
@@ -1,15 +1,16 @@
 package fr.shining_cat.simplehiit.android.mobile.ui.statistics
 
+import fr.shining_cat.simplehiit.commonutils.HiitLogger
 import fr.shining_cat.simplehiit.domain.common.models.DisplayStatisticType
 import fr.shining_cat.simplehiit.domain.common.models.DisplayedStatistic
 import fr.shining_cat.simplehiit.domain.common.models.DurationStringFormatter
 import fr.shining_cat.simplehiit.domain.common.models.UserStatistics
 import fr.shining_cat.simplehiit.domain.common.usecases.FormatLongDurationMsAsSmallestHhMmSsStringUseCase
-import fr.shining_cat.simplehiit.commonutils.HiitLogger
 import javax.inject.Inject
 
-class StatisticsMapper @Inject constructor(
+class StatisticsViewStateMapper @Inject constructor(
     private val formatLongDurationMsAsSmallestHhMmSsStringUseCase: FormatLongDurationMsAsSmallestHhMmSsStringUseCase,
+    @Suppress("unused")
     private val hiitLogger: HiitLogger
 ) {
 

--- a/android/mobile/ui/statistics/src/test/java/fr/shining_cat/simplehiit/android/mobile/ui/statistics/StatisticsViewStateMapperTest.kt
+++ b/android/mobile/ui/statistics/src/test/java/fr/shining_cat/simplehiit/android/mobile/ui/statistics/StatisticsViewStateMapperTest.kt
@@ -18,11 +18,11 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 
-internal class StatisticsMapperTest : AbstractMockkTest() {
+internal class StatisticsViewStateMapperTest : AbstractMockkTest() {
 
     private val mockFormatLongDurationMsAsSmallestHhMmSsStringUseCase =
         mockk<FormatLongDurationMsAsSmallestHhMmSsStringUseCase>()
-    private val testedMapper = StatisticsMapper(
+    private val testedMapper = StatisticsViewStateMapper(
         formatLongDurationMsAsSmallestHhMmSsStringUseCase = mockFormatLongDurationMsAsSmallestHhMmSsStringUseCase,
         hiitLogger = mockHiitLogger
     )


### PR DESCRIPTION
renamed ui layer mappers into xxxViewStateMapper to avoid confusion
updated todo
silenced unused parameter warning for unused hiitLogger parameters, that we still want to keep available