### PR TITLE
replacing collectAsState with collectAsStateWithLifecycle

### DIFF
--- a/android/mobile/ui/home/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/home/HomeScreen.kt
+++ b/android/mobile/ui/home/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/home/HomeScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
@@ -22,6 +21,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.shiningcat.simplehiit.android.mobile.ui.common.UiArrangement
 import fr.shiningcat.simplehiit.android.mobile.ui.common.components.NavigationSideBar
 import fr.shiningcat.simplehiit.android.mobile.ui.common.theme.SimpleHiitMobileTheme
@@ -50,8 +50,8 @@ fun HomeScreen(
             seconds = stringResource(id = R.string.seconds_short),
         )
     viewModel.init(durationsFormatter)
-    val viewState = viewModel.screenViewState.collectAsState().value
-    val dialogViewState = viewModel.dialogViewState.collectAsState().value
+    val viewState = viewModel.screenViewState.collectAsStateWithLifecycle().value
+    val dialogViewState = viewModel.dialogViewState.collectAsStateWithLifecycle().value
     //
     HomeScreen(
         navigateTo = navigateTo,

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreen.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -27,6 +26,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.shiningcat.simplehiit.android.mobile.ui.common.UiArrangement
 import fr.shiningcat.simplehiit.android.mobile.ui.common.components.NavigateUpTopBar
 import fr.shiningcat.simplehiit.android.mobile.ui.common.theme.SimpleHiitMobileTheme
@@ -92,8 +92,8 @@ fun SessionScreen(
         }
     }
     //
-    val screenViewState by viewModel.screenViewState.collectAsState()
-    val dialogViewState by viewModel.dialogViewState.collectAsState()
+    val screenViewState by viewModel.screenViewState.collectAsStateWithLifecycle()
+    val dialogViewState by viewModel.dialogViewState.collectAsStateWithLifecycle()
     //
     SessionScreen(
         onAbortSession = { viewModel.abortSession() },

--- a/android/mobile/ui/settings/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/settings/SettingsScreen.kt
+++ b/android/mobile/ui/settings/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/settings/SettingsScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
@@ -15,6 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.shiningcat.simplehiit.android.mobile.ui.common.UiArrangement
 import fr.shiningcat.simplehiit.android.mobile.ui.common.components.NavigateUpTopBar
 import fr.shiningcat.simplehiit.android.mobile.ui.common.components.NavigationSideBar
@@ -46,8 +46,8 @@ fun SettingsScreen(
             seconds = stringResource(id = R.string.seconds_short),
         )
     viewModel.init(durationsFormatter)
-    val screenViewState = viewModel.screenViewState.collectAsState().value
-    val dialogViewState = viewModel.dialogViewState.collectAsState().value
+    val screenViewState = viewModel.screenViewState.collectAsStateWithLifecycle().value
+    val dialogViewState = viewModel.dialogViewState.collectAsStateWithLifecycle().value
     //
     SettingsScreen(
         navigateTo = navigateTo,

--- a/android/mobile/ui/statistics/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/statistics/StatisticsScreen.kt
+++ b/android/mobile/ui/statistics/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/statistics/StatisticsScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
@@ -15,6 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.shiningcat.simplehiit.android.mobile.ui.common.UiArrangement
 import fr.shiningcat.simplehiit.android.mobile.ui.common.components.NavigateUpTopBar
 import fr.shiningcat.simplehiit.android.mobile.ui.common.components.NavigationSideBar
@@ -46,8 +46,8 @@ fun StatisticsScreen(
         )
     viewModel.init(durationsFormatter)
     //
-    val screenViewState = viewModel.screenViewState.collectAsState().value
-    val dialogViewState = viewModel.dialogViewState.collectAsState().value
+    val screenViewState = viewModel.screenViewState.collectAsStateWithLifecycle().value
+    val dialogViewState = viewModel.dialogViewState.collectAsStateWithLifecycle().value
     //
     StatisticsScreen(
         navigateTo = navigateTo,

--- a/android/tv/ui/home/src/main/java/fr/shiningcat/simplehiit/android/tv/ui/home/HomeScreen.kt
+++ b/android/tv/ui/home/src/main/java/fr/shiningcat/simplehiit/android/tv/ui/home/HomeScreen.kt
@@ -5,7 +5,6 @@ import android.content.res.Configuration
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
@@ -15,6 +14,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.NavigationDrawer
@@ -46,8 +46,8 @@ fun HomeScreen(
             seconds = stringResource(id = R.string.seconds_short),
         )
     viewModel.init(durationsFormatter)
-    val viewState = viewModel.screenViewState.collectAsState().value
-    val dialogViewState = viewModel.dialogViewState.collectAsState().value
+    val viewState = viewModel.screenViewState.collectAsStateWithLifecycle().value
+    val dialogViewState = viewModel.dialogViewState.collectAsStateWithLifecycle().value
     //
     HomeScreen(
         navigateTo = navigateTo,

--- a/android/tv/ui/session/src/main/java/fr/shiningcat/simplehiit/android/tv/ui/session/SessionScreen.kt
+++ b/android/tv/ui/session/src/main/java/fr/shiningcat/simplehiit/android/tv/ui/session/SessionScreen.kt
@@ -5,7 +5,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -21,6 +20,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.NavigationDrawer
@@ -87,8 +87,8 @@ fun SessionScreen(
         }
     }
     //
-    val screenViewState by viewModel.screenViewState.collectAsState()
-    val dialogViewState by viewModel.dialogViewState.collectAsState()
+    val screenViewState by viewModel.screenViewState.collectAsStateWithLifecycle()
+    val dialogViewState by viewModel.dialogViewState.collectAsStateWithLifecycle()
     //
     SessionScreen(
         onAbortSession = { viewModel.abortSession() },

--- a/android/tv/ui/settings/src/main/java/fr/shiningcat/simplehiit/android/tv/ui/settings/SettingsScreen.kt
+++ b/android/tv/ui/settings/src/main/java/fr/shiningcat/simplehiit/android/tv/ui/settings/SettingsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
@@ -13,6 +12,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import fr.shiningcat.simplehiit.android.tv.ui.common.components.NavigationSideBar
@@ -43,8 +43,8 @@ fun SettingsScreen(
             seconds = stringResource(id = R.string.seconds_short),
         )
     viewModel.init(durationsFormatter)
-    val screenViewState = viewModel.screenViewState.collectAsState().value
-    val dialogViewState = viewModel.dialogViewState.collectAsState().value
+    val screenViewState = viewModel.screenViewState.collectAsStateWithLifecycle().value
+    val dialogViewState = viewModel.dialogViewState.collectAsStateWithLifecycle().value
     //
     SettingsScreen(
         navigateTo = navigateTo,

--- a/android/tv/ui/statistics/src/main/java/fr/shiningcat/simplehiit/android/tv/ui/statistics/StatisticsScreen.kt
+++ b/android/tv/ui/statistics/src/main/java/fr/shiningcat/simplehiit/android/tv/ui/statistics/StatisticsScreen.kt
@@ -4,7 +4,6 @@ import android.content.res.Configuration
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
@@ -12,6 +11,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import fr.shiningcat.simplehiit.android.tv.ui.common.components.NavigationSideBar
@@ -42,8 +42,8 @@ fun StatisticsScreen(
         )
     viewModel.init(durationsFormatter)
     //
-    val screenViewState = viewModel.screenViewState.collectAsState().value
-    val dialogViewState = viewModel.dialogViewState.collectAsState().value
+    val screenViewState = viewModel.screenViewState.collectAsStateWithLifecycle().value
+    val dialogViewState = viewModel.dialogViewState.collectAsStateWithLifecycle().value
     //
     StatisticsScreen(
         navigateTo = navigateTo,


### PR DESCRIPTION
Using collectAsStateWithLifecycle() ensures that state collection is lifecycle-aware, preventing unnecessary recompositions and potential memory leaks:
https://medium.com/androiddevelopers/consuming-flows-safely-in-jetpack-compose-cde014d0d5a3