### PR TITLE
Refactor session feature

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,8 @@
 
 ## General technical improvements
 
-* upgrade to androidx.navigation3 (in alpha as of Aug.25) see https://medium.com/proandroiddev/future-of-android-why-navigation-3-is-a-game-changer-f835f841c17f
+* upgrade to androidx.navigation3 (in alpha as of Aug.25) include new adaptive navigation see https://medium.com/proandroiddev/future-of-android-why-navigation-3-is-a-game-changer-f835f841c17f
+* extract all dimensions to res dimen
 * Improve StatusBar tinting and remove the need for deprecated window.statusBarColor=Color. See https://proandroiddev.com/going-edge-to-edge-with-compose-without-losing-it-be6cd093aef7
 * connect deleting jacoco report on build>clean task, it seems that if the folder exists, no new
   report is created?

--- a/android/mobile/ui/common/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/common/AccessibilityHelper.kt
+++ b/android/mobile/ui/common/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/common/AccessibilityHelper.kt
@@ -1,0 +1,22 @@
+package fr.shiningcat.simplehiit.android.mobile.ui.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+val minimumTouchSize: Dp = 44.dp
+
+@Composable
+fun adaptDpToFontScale(
+    baseSize: Dp,
+    coerceMinSize: Dp? = null,
+    coerceMaxSize: Dp? = null
+): Dp {
+    val density = LocalDensity.current
+    val fontScale = density.fontScale
+    val scaledBase = baseSize * fontScale
+    val coercedMin = coerceMinSize?.let { scaledBase.coerceAtLeast(it) } ?: scaledBase
+    val coercedMax = coerceMaxSize?.let { coercedMin.coerceAtMost(it) } ?: scaledBase
+    return coercedMax
+}

--- a/android/mobile/ui/session/build.gradle.kts
+++ b/android/mobile/ui/session/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.google.material)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.adaptive)
     implementation(libs.androidx.compose.preview)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.lifecycle)

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreen.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreen.kt
@@ -1,12 +1,12 @@
 package fr.shiningcat.simplehiit.android.mobile.ui.session
 
-import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -16,16 +16,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.tooling.preview.Devices
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.window.core.layout.WindowHeightSizeClass
+import androidx.window.core.layout.WindowWidthSizeClass
 import fr.shiningcat.simplehiit.android.mobile.ui.common.UiArrangement
 import fr.shiningcat.simplehiit.android.mobile.ui.common.components.NavigateUpTopBar
 import fr.shiningcat.simplehiit.android.mobile.ui.common.theme.SimpleHiitMobileTheme
@@ -188,80 +191,30 @@ private fun SessionScreen(
 }
 
 // Previews
-@Preview(
-    showSystemUi = true,
-    device = Devices.PIXEL_4,
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-    widthDp = 400,
-)
-@Preview(
-    showSystemUi = true,
-    device = Devices.PIXEL_4,
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-    widthDp = 400,
-)
+@PreviewLightDark
+@PreviewFontScale
+@PreviewScreenSizes
 @Composable
-private fun SessionScreenPreviewPhonePortrait(
+private fun SessionScreenPreview(
     @PreviewParameter(SessionScreenPreviewParameterProvider::class) viewState: SessionViewState,
 ) {
-    SimpleHiitMobileTheme {
-        Surface {
-            SessionScreen(
-                dialogViewState = SessionDialog.None,
-                screenViewState = viewState,
-                uiArrangement = UiArrangement.VERTICAL,
-            )
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    val previewUiArrangement: UiArrangement =
+        if (windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.EXPANDED) { // typically, a tablet or bigger in landscape
+            UiArrangement.HORIZONTAL
+        } else { // WindowWidthSizeClass.Medium, WindowWidthSizeClass.Compact :
+            if (windowSizeClass.windowHeightSizeClass == WindowHeightSizeClass.COMPACT) { // typically, a phone in landscape
+                UiArrangement.HORIZONTAL
+            } else {
+                UiArrangement.VERTICAL // typically, a phone or tablet in portrait
+            }
         }
-    }
-}
-
-@Preview(
-    showSystemUi = true,
-    device = "spec:width=1280dp,height=800dp,dpi=240",
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-)
-@Preview(
-    showSystemUi = true,
-    device = "spec:width=1280dp,height=800dp,dpi=240",
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
-@Composable
-private fun SessionScreenPreviewTabletLandscape(
-    @PreviewParameter(SessionScreenPreviewParameterProvider::class) viewState: SessionViewState,
-) {
     SimpleHiitMobileTheme {
         Surface {
             SessionScreen(
                 dialogViewState = SessionDialog.None,
                 screenViewState = viewState,
-                uiArrangement = UiArrangement.HORIZONTAL,
-            )
-        }
-    }
-}
-
-@Preview(
-    showSystemUi = true,
-    device = "spec:parent=pixel_4,orientation=landscape",
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-    heightDp = 400,
-)
-@Preview(
-    showSystemUi = true,
-    device = "spec:parent=pixel_4,orientation=landscape",
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-    heightDp = 400,
-)
-@Composable
-private fun SessionScreenPreviewPhoneLandscape(
-    @PreviewParameter(SessionScreenPreviewParameterProvider::class) viewState: SessionViewState,
-) {
-    SimpleHiitMobileTheme {
-        Surface {
-            SessionScreen(
-                dialogViewState = SessionDialog.None,
-                screenViewState = viewState,
-                uiArrangement = UiArrangement.HORIZONTAL,
+                uiArrangement = previewUiArrangement,
             )
         }
     }

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreen.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreen.kt
@@ -141,6 +141,7 @@ fun SessionScreen(
                     navigateUp,
                 )
         }
+    // manually building layout instead of using native Scaffold to get more flexibility:
     Row(modifier = Modifier.fillMaxSize()) {
         AnimatedVisibility(visible = uiArrangement == UiArrangement.HORIZONTAL) {
             SessionSideBarComponent(

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreen.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreen.kt
@@ -5,8 +5,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Surface
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -16,29 +14,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.tooling.preview.PreviewFontScale
-import androidx.compose.ui.tooling.preview.PreviewLightDark
-import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.window.core.layout.WindowHeightSizeClass
-import androidx.window.core.layout.WindowWidthSizeClass
 import fr.shiningcat.simplehiit.android.mobile.ui.common.UiArrangement
 import fr.shiningcat.simplehiit.android.mobile.ui.common.components.NavigateUpTopBar
-import fr.shiningcat.simplehiit.android.mobile.ui.common.theme.SimpleHiitMobileTheme
 import fr.shiningcat.simplehiit.android.mobile.ui.session.components.SessionSideBarComponent
 import fr.shiningcat.simplehiit.android.mobile.ui.session.contents.SessionContentHolder
 import fr.shiningcat.simplehiit.commonresources.R
 import fr.shiningcat.simplehiit.commonutils.HiitLogger
-import fr.shiningcat.simplehiit.domain.common.models.Exercise
-import fr.shiningcat.simplehiit.domain.common.models.ExerciseSide
-import fr.shiningcat.simplehiit.domain.common.models.SessionStepDisplay
 
 @Composable
 fun SessionScreen(
@@ -92,7 +79,7 @@ fun SessionScreen(
 }
 
 @Composable
-private fun SessionScreen(
+fun SessionScreen(
     navigateUp: () -> Boolean = { true },
     onAbortSession: () -> Unit = {},
     pause: () -> Unit = {},
@@ -188,137 +175,4 @@ private fun SessionScreen(
             )
         }
     }
-}
-
-// Previews
-@PreviewLightDark
-@PreviewFontScale
-@PreviewScreenSizes
-@Composable
-private fun SessionScreenPreview(
-    @PreviewParameter(SessionScreenPreviewParameterProvider::class) viewState: SessionViewState,
-) {
-    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
-    val previewUiArrangement: UiArrangement =
-        if (windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.EXPANDED) { // typically, a tablet or bigger in landscape
-            UiArrangement.HORIZONTAL
-        } else { // WindowWidthSizeClass.Medium, WindowWidthSizeClass.Compact :
-            if (windowSizeClass.windowHeightSizeClass == WindowHeightSizeClass.COMPACT) { // typically, a phone in landscape
-                UiArrangement.HORIZONTAL
-            } else {
-                UiArrangement.VERTICAL // typically, a phone or tablet in portrait
-            }
-        }
-    SimpleHiitMobileTheme {
-        Surface {
-            SessionScreen(
-                dialogViewState = SessionDialog.None,
-                screenViewState = viewState,
-                uiArrangement = previewUiArrangement,
-            )
-        }
-    }
-}
-
-internal class SessionScreenPreviewParameterProvider : PreviewParameterProvider<SessionViewState> {
-    override val values: Sequence<SessionViewState>
-        get() =
-            sequenceOf(
-                SessionViewState.Loading,
-                SessionViewState.Error("Blabla error code"),
-                SessionViewState.InitialCountDownSession(
-                    countDown =
-                        CountDown(
-                            secondsDisplay = "3",
-                            progress = .5f,
-                            playBeep = true,
-                        ),
-                ),
-                SessionViewState.RunningNominal(
-                    periodType = RunningSessionStepType.REST,
-                    displayedExercise = Exercise.CatBackLegLift,
-                    side = ExerciseSide.RIGHT,
-                    stepRemainingTime = "25s",
-                    stepRemainingPercentage = .53f,
-                    sessionRemainingTime = "16mn 23s",
-                    sessionRemainingPercentage = .24f,
-                ),
-                SessionViewState.RunningNominal(
-                    periodType = RunningSessionStepType.REST,
-                    displayedExercise = Exercise.CatBackLegLift,
-                    side = ExerciseSide.RIGHT,
-                    stepRemainingTime = "25s",
-                    stepRemainingPercentage = .53f,
-                    sessionRemainingTime = "16mn 23s",
-                    sessionRemainingPercentage = .24f,
-                    countDown =
-                        CountDown(
-                            secondsDisplay = "3",
-                            progress = .5f,
-                            playBeep = true,
-                        ),
-                ),
-                SessionViewState.RunningNominal(
-                    periodType = RunningSessionStepType.REST,
-                    displayedExercise = Exercise.CatBackLegLift,
-                    side = ExerciseSide.RIGHT,
-                    stepRemainingTime = "25s",
-                    stepRemainingPercentage = .23f,
-                    sessionRemainingTime = "16mn 23s",
-                    sessionRemainingPercentage = .57f,
-                ),
-                SessionViewState.RunningNominal(
-                    periodType = RunningSessionStepType.WORK,
-                    displayedExercise = Exercise.CrabAdvancedBridge,
-                    side = ExerciseSide.NONE,
-                    stepRemainingTime = "3s",
-                    stepRemainingPercentage = .7f,
-                    sessionRemainingTime = "5mn 12s",
-                    sessionRemainingPercentage = .3f,
-                ),
-                SessionViewState.RunningNominal(
-                    periodType = RunningSessionStepType.WORK,
-                    displayedExercise = Exercise.CrabAdvancedBridge,
-                    side = ExerciseSide.NONE,
-                    stepRemainingTime = "3s",
-                    stepRemainingPercentage = .7f,
-                    sessionRemainingTime = "5mn 12s",
-                    sessionRemainingPercentage = .3f,
-                    countDown =
-                        CountDown(
-                            secondsDisplay = "5",
-                            progress = 0f,
-                            playBeep = false,
-                        ),
-                ),
-                SessionViewState.RunningNominal(
-                    periodType = RunningSessionStepType.WORK,
-                    displayedExercise = Exercise.CrabAdvancedBridge,
-                    side = ExerciseSide.LEFT,
-                    stepRemainingTime = "3s",
-                    stepRemainingPercentage = .5f,
-                    sessionRemainingTime = "5mn 12s",
-                    sessionRemainingPercentage = .2f,
-                ),
-                SessionViewState.Finished(
-                    "16mn",
-                    workingStepsDone =
-                        listOf(
-                            SessionStepDisplay(Exercise.CatBackLegLift, ExerciseSide.NONE),
-                            SessionStepDisplay(Exercise.CatKneePushUp, ExerciseSide.NONE),
-                            SessionStepDisplay(Exercise.LungesArmsCrossSide, ExerciseSide.LEFT),
-                            SessionStepDisplay(Exercise.LungesArmsCrossSide, ExerciseSide.RIGHT),
-                            SessionStepDisplay(Exercise.LungesTwist, ExerciseSide.NONE),
-                            SessionStepDisplay(Exercise.LyingStarToeTouchSitUp, ExerciseSide.NONE),
-                            SessionStepDisplay(Exercise.LyingSupermanTwist, ExerciseSide.NONE),
-                            SessionStepDisplay(Exercise.StandingMountainClimber, ExerciseSide.NONE),
-                            SessionStepDisplay(Exercise.PlankMountainClimber, ExerciseSide.LEFT),
-                            SessionStepDisplay(Exercise.PlankMountainClimber, ExerciseSide.RIGHT),
-                            SessionStepDisplay(Exercise.StandingKickCrunches, ExerciseSide.NONE),
-                            SessionStepDisplay(Exercise.SquatBasic, ExerciseSide.NONE),
-                            SessionStepDisplay(Exercise.PlankShoulderTap, ExerciseSide.NONE),
-                            SessionStepDisplay(Exercise.PlankBirdDogs, ExerciseSide.NONE),
-                        ),
-                ),
-            )
 }

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreen.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreen.kt
@@ -46,17 +46,10 @@ fun SessionScreen(
     lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
 ) {
     // Handling the sound loading in the viewModel's soundPool:
-    if (viewModel.noSoundLoadingRequestedYet) {
+    if (viewModel.isSoundLoaded().not()) {
         hiitLogger.d("SessionScreen", "loading beep sound in SoundPool")
         // we want this loading to only happen once, to benefit from the pooling and avoid playback latency, but SideEffects wouldn't let us access the context we need
-        val beepSoundLoadedInPool =
-            viewModel.getSoundPool()?.load(LocalContext.current, R.raw.sound_beep, 0)
-        viewModel.noSoundLoadingRequestedYet = false
-        if (beepSoundLoadedInPool == null) {
-            hiitLogger.e("SessionScreen", "beepSoundLoadedInPool is null, no sound will be played")
-        } else {
-            viewModel.setLoadedSound(beepSoundLoadedInPool)
-        }
+        viewModel.getSoundPool()?.load(LocalContext.current, R.raw.sound_beep, 0)
     }
     // Setting up a LifeCycle observer to catch the onPause event of the Android Lifecycle so we can pause the session
     var lifecycleEvent by remember { mutableStateOf(Lifecycle.Event.ON_ANY) }

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreen.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -26,6 +24,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import fr.shiningcat.simplehiit.android.mobile.ui.common.UiArrangement
 import fr.shiningcat.simplehiit.android.mobile.ui.common.components.NavigateUpTopBar
@@ -34,7 +33,6 @@ import fr.shiningcat.simplehiit.android.mobile.ui.session.components.SessionSide
 import fr.shiningcat.simplehiit.android.mobile.ui.session.contents.SessionContentHolder
 import fr.shiningcat.simplehiit.commonresources.R
 import fr.shiningcat.simplehiit.commonutils.HiitLogger
-import fr.shiningcat.simplehiit.domain.common.models.DurationStringFormatter
 import fr.shiningcat.simplehiit.domain.common.models.Exercise
 import fr.shiningcat.simplehiit.domain.common.models.ExerciseSide
 import fr.shiningcat.simplehiit.domain.common.models.SessionStepDisplay
@@ -47,16 +45,6 @@ fun SessionScreen(
     viewModel: SessionViewModel = hiltViewModel(),
     lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
 ) {
-    val durationsFormatter =
-        DurationStringFormatter(
-            hoursMinutesSeconds = stringResource(id = R.string.hours_minutes_seconds_short),
-            hoursMinutesNoSeconds = stringResource(id = R.string.hours_minutes_no_seconds_short),
-            hoursNoMinutesNoSeconds = stringResource(id = R.string.hours_no_minutes_no_seconds_short),
-            minutesSeconds = stringResource(id = R.string.minutes_seconds_short),
-            minutesNoSeconds = stringResource(id = R.string.minutes_no_seconds_short),
-            seconds = stringResource(id = R.string.seconds_short),
-        )
-    viewModel.init(durationsFormatter)
     // Handling the sound loading in the viewModel's soundPool:
     if (viewModel.noSoundLoadingRequestedYet) {
         hiitLogger.d("SessionScreen", "loading beep sound in SoundPool")

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreenPreview.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionScreenPreview.kt
@@ -1,0 +1,150 @@
+package fr.shiningcat.simplehiit.android.mobile.ui.session
+
+import androidx.compose.material3.Surface
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
+import androidx.window.core.layout.WindowHeightSizeClass
+import androidx.window.core.layout.WindowWidthSizeClass
+import fr.shiningcat.simplehiit.android.mobile.ui.common.UiArrangement
+import fr.shiningcat.simplehiit.android.mobile.ui.common.theme.SimpleHiitMobileTheme
+import fr.shiningcat.simplehiit.domain.common.models.Exercise
+import fr.shiningcat.simplehiit.domain.common.models.ExerciseSide
+import fr.shiningcat.simplehiit.domain.common.models.SessionStepDisplay
+
+// Previews
+@PreviewLightDark
+@PreviewFontScale
+@PreviewScreenSizes
+@Composable
+fun SessionScreenPreview(
+    @PreviewParameter(SessionScreenPreviewParameterProvider::class) viewState: SessionViewState,
+) {
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    val previewUiArrangement: UiArrangement =
+        if (windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.EXPANDED) { // typically, a tablet or bigger in landscape
+            UiArrangement.HORIZONTAL
+        } else { // WindowWidthSizeClass.Medium, WindowWidthSizeClass.Compact :
+            if (windowSizeClass.windowHeightSizeClass == WindowHeightSizeClass.COMPACT) { // typically, a phone in landscape
+                UiArrangement.HORIZONTAL
+            } else {
+                UiArrangement.VERTICAL // typically, a phone or tablet in portrait
+            }
+        }
+    SimpleHiitMobileTheme {
+        Surface {
+            SessionScreen(
+                dialogViewState = SessionDialog.None,
+                screenViewState = viewState,
+                uiArrangement = previewUiArrangement,
+            )
+        }
+    }
+}
+
+internal class SessionScreenPreviewParameterProvider : PreviewParameterProvider<SessionViewState> {
+    override val values: Sequence<SessionViewState>
+        get() =
+            sequenceOf(
+                SessionViewState.Loading,
+                SessionViewState.Error("Blabla error code"),
+                SessionViewState.InitialCountDownSession(
+                    countDown =
+                        CountDown(
+                            secondsDisplay = "3",
+                            progress = .5f,
+                            playBeep = true,
+                        ),
+                ),
+                SessionViewState.RunningNominal(
+                    periodType = RunningSessionStepType.REST,
+                    displayedExercise = Exercise.CatBackLegLift,
+                    side = ExerciseSide.RIGHT,
+                    stepRemainingTime = "25s",
+                    stepRemainingPercentage = .53f,
+                    sessionRemainingTime = "16mn 23s",
+                    sessionRemainingPercentage = .24f,
+                ),
+                SessionViewState.RunningNominal(
+                    periodType = RunningSessionStepType.REST,
+                    displayedExercise = Exercise.CatBackLegLift,
+                    side = ExerciseSide.RIGHT,
+                    stepRemainingTime = "25s",
+                    stepRemainingPercentage = .53f,
+                    sessionRemainingTime = "16mn 23s",
+                    sessionRemainingPercentage = .24f,
+                    countDown =
+                        CountDown(
+                            secondsDisplay = "3",
+                            progress = .5f,
+                            playBeep = true,
+                        ),
+                ),
+                SessionViewState.RunningNominal(
+                    periodType = RunningSessionStepType.REST,
+                    displayedExercise = Exercise.CatBackLegLift,
+                    side = ExerciseSide.RIGHT,
+                    stepRemainingTime = "25s",
+                    stepRemainingPercentage = .23f,
+                    sessionRemainingTime = "16mn 23s",
+                    sessionRemainingPercentage = .57f,
+                ),
+                SessionViewState.RunningNominal(
+                    periodType = RunningSessionStepType.WORK,
+                    displayedExercise = Exercise.CrabAdvancedBridge,
+                    side = ExerciseSide.NONE,
+                    stepRemainingTime = "3s",
+                    stepRemainingPercentage = .7f,
+                    sessionRemainingTime = "5mn 12s",
+                    sessionRemainingPercentage = .3f,
+                ),
+                SessionViewState.RunningNominal(
+                    periodType = RunningSessionStepType.WORK,
+                    displayedExercise = Exercise.CrabAdvancedBridge,
+                    side = ExerciseSide.NONE,
+                    stepRemainingTime = "3s",
+                    stepRemainingPercentage = .7f,
+                    sessionRemainingTime = "5mn 12s",
+                    sessionRemainingPercentage = .3f,
+                    countDown =
+                        CountDown(
+                            secondsDisplay = "5",
+                            progress = 0f,
+                            playBeep = false,
+                        ),
+                ),
+                SessionViewState.RunningNominal(
+                    periodType = RunningSessionStepType.WORK,
+                    displayedExercise = Exercise.CrabAdvancedBridge,
+                    side = ExerciseSide.LEFT,
+                    stepRemainingTime = "3s",
+                    stepRemainingPercentage = .5f,
+                    sessionRemainingTime = "5mn 12s",
+                    sessionRemainingPercentage = .2f,
+                ),
+                SessionViewState.Finished(
+                    "16mn",
+                    workingStepsDone =
+                        listOf(
+                            SessionStepDisplay(Exercise.CatBackLegLift, ExerciseSide.NONE),
+                            SessionStepDisplay(Exercise.CatKneePushUp, ExerciseSide.NONE),
+                            SessionStepDisplay(Exercise.LungesArmsCrossSide, ExerciseSide.LEFT),
+                            SessionStepDisplay(Exercise.LungesArmsCrossSide, ExerciseSide.RIGHT),
+                            SessionStepDisplay(Exercise.LungesTwist, ExerciseSide.NONE),
+                            SessionStepDisplay(Exercise.LyingStarToeTouchSitUp, ExerciseSide.NONE),
+                            SessionStepDisplay(Exercise.LyingSupermanTwist, ExerciseSide.NONE),
+                            SessionStepDisplay(Exercise.StandingMountainClimber, ExerciseSide.NONE),
+                            SessionStepDisplay(Exercise.PlankMountainClimber, ExerciseSide.LEFT),
+                            SessionStepDisplay(Exercise.PlankMountainClimber, ExerciseSide.RIGHT),
+                            SessionStepDisplay(Exercise.StandingKickCrunches, ExerciseSide.NONE),
+                            SessionStepDisplay(Exercise.SquatBasic, ExerciseSide.NONE),
+                            SessionStepDisplay(Exercise.PlankShoulderTap, ExerciseSide.NONE),
+                            SessionStepDisplay(Exercise.PlankBirdDogs, ExerciseSide.NONE),
+                        ),
+                ),
+            )
+}

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionViewModel.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionViewModel.kt
@@ -34,6 +34,7 @@ class SessionViewModel
         private val soundPool: SoundPool,
         private val hiitLogger: HiitLogger,
     ) : ViewModel() {
+        //
         private val _screenViewState =
             MutableStateFlow<SessionViewState>(SessionViewState.Loading)
         val screenViewState = _screenViewState.asStateFlow()

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionViewStateMapper.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionViewStateMapper.kt
@@ -95,27 +95,6 @@ class SessionViewStateMapper
                             sessionRemainingPercentage = currentStepTimerState.remainingPercentage,
                             countDown = periodCountDown,
                         )
-                /*
-                                is SessionStep.RestStep -> SessionViewState.RestNominal(
-                                    nextExercise = currentStep.exercise,
-                                    side = currentStep.side,
-                                    restRemainingTime = stepRemainingFormatted,
-                                    restRemainingPercentage = stepRemainingPercentage,
-                                    sessionRemainingTime = sessionRemainingFormatted,
-                                    sessionRemainingPercentage = currentStepTimerState.remainingPercentage,
-                                    countDown = periodCountDown,
-                                )
-
-                                is SessionStep.WorkStep -> SessionViewState.WorkNominal(
-                                    currentExercise = currentStep.exercise,
-                                    side = currentStep.side,
-                                    exerciseRemainingTime = stepRemainingFormatted,
-                                    exerciseRemainingPercentage = stepRemainingPercentage,
-                                    sessionRemainingTime = sessionRemainingFormatted,
-                                    sessionRemainingPercentage = currentStepTimerState.remainingPercentage,
-                                    countDown = periodCountDown,
-                                )
-                 */
                 }
             }
     }

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/components/CountDownComponent.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/components/CountDownComponent.kt
@@ -1,6 +1,5 @@
 package fr.shiningcat.simplehiit.android.mobile.ui.session.components
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,23 +12,33 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import fr.shiningcat.simplehiit.android.mobile.ui.common.adaptDpToFontScale
 import fr.shiningcat.simplehiit.android.mobile.ui.common.theme.SimpleHiitMobileTheme
 import fr.shiningcat.simplehiit.android.mobile.ui.session.CountDown
 import fr.shiningcat.simplehiit.commonutils.HiitLogger
 
+/**
+ * Displays a circular progress indicator with a countdown timer.
+ *
+ * @param baseSize The size of the component, will adapt to fontScale, but not to countDown value (more digits need more room)
+ * @param countDown The [CountDown] data to display
+ * @param hiitLogger An optional [HiitLogger] for logging. (Currently unused)
+ */
 @Composable
 fun CountDownComponent(
-    size: Dp,
+    baseSize: Dp,
     countDown: CountDown,
     @Suppress("UNUSED_PARAMETER")
     hiitLogger: HiitLogger? = null,
 ) {
+    val adaptedSize = adaptDpToFontScale(baseSize)
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier.size(size),
+        modifier = Modifier.size(adaptedSize),
     ) {
         // this first never-moving one is to simulate the trackColor from a LinearProgressIndicator
         CircularProgressIndicator(
@@ -37,7 +46,7 @@ fun CountDownComponent(
                 Modifier
                     .align(Alignment.Center)
                     .fillMaxSize(),
-            progress = 1f,
+            progress = { 1f },
             strokeWidth = 5.dp,
             color = MaterialTheme.colorScheme.primary,
         )
@@ -46,7 +55,7 @@ fun CountDownComponent(
                 Modifier
                     .align(Alignment.Center)
                     .fillMaxSize(),
-            progress = countDown.progress,
+            progress = { countDown.progress },
             strokeWidth = 5.dp,
             color = MaterialTheme.colorScheme.secondary,
         )
@@ -60,14 +69,8 @@ fun CountDownComponent(
 }
 
 // Previews
-@Preview(
-    showBackground = true,
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-)
-@Preview(
-    showBackground = true,
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
+@PreviewLightDark
+@PreviewFontScale
 @Composable
 private fun CountDownCircularProgressPreview() {
     SimpleHiitMobileTheme {
@@ -78,35 +81,35 @@ private fun CountDownCircularProgressPreview() {
                 verticalArrangement = Arrangement.SpaceEvenly,
             ) {
                 CountDownComponent(
-                    size = 48.dp,
-                    countDown = CountDown(secondsDisplay = "35", progress = 1f, playBeep = true),
+                    baseSize = 48.dp,
+                    countDown = CountDown(secondsDisplay = "35.5", progress = 1f, playBeep = true),
                 )
                 CountDownComponent(
-                    size = 48.dp,
+                    baseSize = 48.dp,
                     countDown = CountDown(secondsDisplay = "21", progress = .9f, playBeep = true),
                 )
                 CountDownComponent(
-                    size = 48.dp,
+                    baseSize = 48.dp,
                     countDown = CountDown(secondsDisplay = "17", progress = .7f, playBeep = true),
                 )
                 CountDownComponent(
-                    size = 48.dp,
+                    baseSize = 48.dp,
                     countDown = CountDown(secondsDisplay = "9", progress = .5f, playBeep = true),
                 )
                 CountDownComponent(
-                    size = 48.dp,
+                    baseSize = 48.dp,
                     countDown = CountDown(secondsDisplay = "4", progress = .3f, playBeep = true),
                 )
                 CountDownComponent(
-                    size = 48.dp,
+                    baseSize = 48.dp,
                     countDown = CountDown(secondsDisplay = "3", progress = .2f, playBeep = true),
                 )
                 CountDownComponent(
-                    size = 48.dp,
+                    baseSize = 48.dp,
                     countDown = CountDown(secondsDisplay = "2", progress = .1f, playBeep = true),
                 )
                 CountDownComponent(
-                    size = 48.dp,
+                    baseSize = 48.dp,
                     countDown = CountDown(secondsDisplay = "0", progress = 0f, playBeep = true),
                 )
             }

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/components/ExerciseDescriptionComponent.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/components/ExerciseDescriptionComponent.kt
@@ -1,6 +1,5 @@
 package fr.shiningcat.simplehiit.android.mobile.ui.session.components
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,7 +12,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import fr.shiningcat.simplehiit.android.mobile.ui.common.theme.SimpleHiitMobileTheme
 import fr.shiningcat.simplehiit.commonresources.R
 import fr.shiningcat.simplehiit.commonresources.helpers.ExerciseDisplayNameMapper
@@ -53,14 +53,8 @@ fun ExerciseDescriptionComponent(
 }
 
 // Previews
-@Preview(
-    showBackground = true,
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-)
-@Preview(
-    showBackground = true,
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
+@PreviewLightDark
+@PreviewFontScale
 @Composable
 private fun CountDownCircularProgressPreview() {
     SimpleHiitMobileTheme {

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/components/ExerciseDisplayComponent.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/components/ExerciseDisplayComponent.kt
@@ -1,13 +1,13 @@
 package fr.shiningcat.simplehiit.android.mobile.ui.session.components
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import fr.shiningcat.simplehiit.android.common.ui.components.GifImage
 import fr.shiningcat.simplehiit.android.mobile.ui.common.theme.SimpleHiitMobileTheme
@@ -37,7 +37,7 @@ fun ExerciseDisplayComponent(
         )
         if (countDown != null) {
             CountDownComponent(
-                size = 48.dp,
+                baseSize = 48.dp,
                 countDown = countDown,
                 hiitLogger = hiitLogger,
             )
@@ -46,12 +46,8 @@ fun ExerciseDisplayComponent(
 }
 
 // Previews
-@Preview(
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-)
-@Preview(
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
+@PreviewLightDark
+@PreviewFontScale
 @Composable
 private fun ExerciseDisplayComponentPreview() {
     SimpleHiitMobileTheme {

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/components/RemainingPercentageComponent.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/components/RemainingPercentageComponent.kt
@@ -37,7 +37,7 @@ fun RemainingPercentageComponent(
         Text(
             text = label,
             style = MaterialTheme.typography.titleLarge,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
         )
         LinearProgressIndicator(
             progress = { percentage },

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/components/RemainingPercentageComponent.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/components/RemainingPercentageComponent.kt
@@ -1,6 +1,5 @@
 package fr.shiningcat.simplehiit.android.mobile.ui.session.components
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,7 +14,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import fr.shiningcat.simplehiit.android.mobile.ui.common.theme.SimpleHiitMobileTheme
@@ -36,6 +37,7 @@ fun RemainingPercentageComponent(
         Text(
             text = label,
             style = MaterialTheme.typography.titleLarge,
+            textAlign = TextAlign.Center
         )
         LinearProgressIndicator(
             progress = { percentage },
@@ -53,12 +55,8 @@ fun RemainingPercentageComponent(
 }
 
 // Previews
-@Preview(
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-)
-@Preview(
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
+@PreviewLightDark
+@PreviewFontScale
 @Composable
 private fun RemainingPercentageComponentPreview() {
     SimpleHiitMobileTheme {
@@ -81,7 +79,7 @@ private fun RemainingPercentageComponentPreview() {
                     modifier =
                         Modifier
                             .padding(horizontal = 16.dp),
-                    label = "Next rest in 23s",
+                    label = "Next rest in 7mn\u00A023s",
                     percentage = .8f,
                     thickness = 8.dp,
                     bicolor = false,
@@ -90,7 +88,7 @@ private fun RemainingPercentageComponentPreview() {
                     modifier =
                         Modifier
                             .padding(horizontal = 16.dp),
-                    label = "Total remaining: 20mn 37s",
+                    label = "Total remaining: 1h\u00A020mn\u00A037s",
                     percentage = .79f,
                     thickness = 16.dp,
                     bicolor = true,

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/components/SessionSideBarComponent.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/components/SessionSideBarComponent.kt
@@ -1,6 +1,5 @@
 package fr.shiningcat.simplehiit.android.mobile.ui.session.components
 
-import android.content.res.Configuration
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
@@ -11,7 +10,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import fr.shiningcat.simplehiit.android.mobile.ui.common.components.SideBarItem
 import fr.shiningcat.simplehiit.android.mobile.ui.common.theme.SimpleHiitMobileTheme
@@ -46,12 +46,8 @@ fun SessionSideBarComponent(
 }
 
 // Previews
-@Preview(
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-)
-@Preview(
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
+@PreviewLightDark
+@PreviewFontScale
 @Composable
 private fun SessionSideBarComponentPreview() {
     SimpleHiitMobileTheme {

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/contents/SessionContentHolder.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/contents/SessionContentHolder.kt
@@ -1,8 +1,8 @@
 package fr.shiningcat.simplehiit.android.mobile.ui.session.contents
 
-import android.content.res.Configuration
 import android.view.View
 import androidx.compose.material3.Surface
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -10,10 +10,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Devices
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
+import androidx.window.core.layout.WindowHeightSizeClass
+import androidx.window.core.layout.WindowWidthSizeClass
 import fr.shiningcat.simplehiit.android.mobile.ui.common.UiArrangement
 import fr.shiningcat.simplehiit.android.mobile.ui.common.components.BasicLoading
 import fr.shiningcat.simplehiit.android.mobile.ui.common.components.ChoiceDialog
@@ -127,80 +130,30 @@ private fun handleScreenLock(
 }
 
 // Previews
-@Preview(
-    showSystemUi = true,
-    device = Devices.PIXEL_4,
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-    widthDp = 400,
-)
-@Preview(
-    showSystemUi = true,
-    device = Devices.PIXEL_4,
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-    widthDp = 400,
-)
+@PreviewLightDark
+@PreviewFontScale
+@PreviewScreenSizes
 @Composable
-private fun SessionContentHolderPreviewPhonePortrait(
+private fun SessionContentHolderPreview(
     @PreviewParameter(SessionContentHolderPreviewParameterProvider::class) viewState: SessionViewState,
 ) {
-    SimpleHiitMobileTheme {
-        Surface {
-            SessionContentHolder(
-                dialogViewState = SessionDialog.None,
-                screenViewState = viewState,
-                uiArrangement = UiArrangement.VERTICAL,
-            )
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    val previewUiArrangement: UiArrangement =
+        if (windowSizeClass.windowWidthSizeClass == WindowWidthSizeClass.EXPANDED) { // typically, a tablet or bigger in landscape
+            UiArrangement.HORIZONTAL
+        } else { // WindowWidthSizeClass.Medium, WindowWidthSizeClass.Compact :
+            if (windowSizeClass.windowHeightSizeClass == WindowHeightSizeClass.COMPACT) { // typically, a phone in landscape
+                UiArrangement.HORIZONTAL
+            } else {
+                UiArrangement.VERTICAL // typically, a phone or tablet in portrait
+            }
         }
-    }
-}
-
-@Preview(
-    showSystemUi = true,
-    device = "spec:width=1280dp,height=800dp,dpi=240",
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-)
-@Preview(
-    showSystemUi = true,
-    device = "spec:width=1280dp,height=800dp,dpi=240",
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
-@Composable
-private fun SessionContentHolderPreviewTabletLandscape(
-    @PreviewParameter(SessionContentHolderPreviewParameterProvider::class) viewState: SessionViewState,
-) {
     SimpleHiitMobileTheme {
         Surface {
             SessionContentHolder(
                 dialogViewState = SessionDialog.None,
                 screenViewState = viewState,
-                uiArrangement = UiArrangement.HORIZONTAL,
-            )
-        }
-    }
-}
-
-@Preview(
-    showSystemUi = true,
-    device = "spec:parent=pixel_4,orientation=landscape",
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-    heightDp = 400,
-)
-@Preview(
-    showSystemUi = true,
-    device = "spec:parent=pixel_4,orientation=landscape",
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-    heightDp = 400,
-)
-@Composable
-private fun SessionContentHolderPreviewPhoneLandscape(
-    @PreviewParameter(SessionContentHolderPreviewParameterProvider::class) viewState: SessionViewState,
-) {
-    SimpleHiitMobileTheme {
-        Surface {
-            SessionContentHolder(
-                dialogViewState = SessionDialog.None,
-                screenViewState = viewState,
-                uiArrangement = UiArrangement.HORIZONTAL,
+                uiArrangement = previewUiArrangement,
             )
         }
     }

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/contents/SessionErrorStateContent.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/contents/SessionErrorStateContent.kt
@@ -1,6 +1,5 @@
 package fr.shiningcat.simplehiit.android.mobile.ui.session.contents
 
-import android.content.res.Configuration
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,7 +18,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
@@ -105,12 +105,8 @@ fun SessionErrorStateContent(
 }
 
 // Previews
-@Preview(
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-)
-@Preview(
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
+@PreviewLightDark
+@PreviewFontScale
 @Composable
 private fun SessionErrorStateContentPreview(
     @PreviewParameter(SessionErrorStateContentPreviewParameterProvider::class) sessionViewState: SessionViewState.Error,

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/contents/SessionFinishedContent.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/contents/SessionFinishedContent.kt
@@ -1,6 +1,5 @@
 package fr.shiningcat.simplehiit.android.mobile.ui.session.contents
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,7 +17,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
@@ -139,12 +139,8 @@ fun SessionFinishedExerciseDoneItemComponent(
 }
 
 // Previews
-@Preview(
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-)
-@Preview(
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
+@PreviewLightDark
+@PreviewFontScale
 @Composable
 private fun SessionFinishedContentPreview(
     @PreviewParameter(SessionFinishedContentPreviewParameterProvider::class) viewState: SessionViewState.Finished,

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/contents/SessionPrepareContent.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/contents/SessionPrepareContent.kt
@@ -1,13 +1,13 @@
 package fr.shiningcat.simplehiit.android.mobile.ui.session.contents
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import fr.shiningcat.simplehiit.android.mobile.ui.common.theme.SimpleHiitMobileTheme
 import fr.shiningcat.simplehiit.android.mobile.ui.session.CountDown
@@ -26,7 +26,7 @@ fun SessionPrepareContent(
         contentAlignment = Alignment.Center,
     ) {
         CountDownComponent(
-            size = 64.dp,
+            baseSize = 64.dp,
             countDown = viewState.countDown,
             hiitLogger = hiitLogger,
         )
@@ -34,12 +34,8 @@ fun SessionPrepareContent(
 }
 
 // Previews
-@Preview(
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-)
-@Preview(
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
+@PreviewLightDark
+@PreviewFontScale
 @Composable
 private fun SessionPrepareContentPreview() {
     SimpleHiitMobileTheme {

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/contents/SessionRunningNominalContent.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/contents/SessionRunningNominalContent.kt
@@ -1,6 +1,5 @@
 package fr.shiningcat.simplehiit.android.mobile.ui.session.contents
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -18,10 +17,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.tooling.preview.Devices
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import fr.shiningcat.simplehiit.android.mobile.ui.common.UiArrangement
 import fr.shiningcat.simplehiit.android.mobile.ui.common.theme.SimpleHiitMobileTheme
@@ -156,102 +156,17 @@ fun HorizontalSessionRunningNominalContent(
 }
 
 // Previews
-@Preview(
-    showSystemUi = true,
-    device = Devices.PIXEL_4,
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-    widthDp = 400,
-)
-@Preview(
-    showSystemUi = true,
-    device = Devices.PIXEL_4,
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-    widthDp = 400,
-)
+@PreviewLightDark
+@PreviewFontScale
+@PreviewScreenSizes
 @Composable
-private fun SessionRunningNominalContentPreviewPhonePortrait(
+private fun SessionRunningNominalContentPreview(
     @PreviewParameter(SessionRunningNominalContentPreviewParameterProvider::class) viewState: SessionViewState.RunningNominal,
 ) {
     SimpleHiitMobileTheme {
         Surface {
             SessionRunningNominalContent(
                 uiArrangement = UiArrangement.VERTICAL,
-                viewState = viewState,
-            )
-        }
-    }
-}
-
-@Preview(
-    showSystemUi = true,
-    device = "spec:width=400dp,height=700dp,dpi=240",
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-    widthDp = 400,
-)
-@Preview(
-    showSystemUi = true,
-    device = "spec:width=400dp,height=700dp,dpi=240",
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-    widthDp = 400,
-)
-@Composable
-private fun SessionRunningNominalContentPreviewSmallPhonePortrait(
-    @PreviewParameter(SessionRunningNominalContentPreviewParameterProvider::class) viewState: SessionViewState.RunningNominal,
-) {
-    SimpleHiitMobileTheme {
-        Surface {
-            SessionRunningNominalContent(
-                uiArrangement = UiArrangement.VERTICAL,
-                viewState = viewState,
-            )
-        }
-    }
-}
-
-@Preview(
-    showSystemUi = true,
-    device = "spec:width=1280dp,height=800dp,dpi=240",
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-)
-@Preview(
-    showSystemUi = true,
-    device = "spec:width=1280dp,height=800dp,dpi=240",
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-)
-@Composable
-private fun SessionRunningNominalContentPreviewTabletLandscape(
-    @PreviewParameter(SessionRunningNominalContentPreviewParameterProvider::class) viewState: SessionViewState.RunningNominal,
-) {
-    SimpleHiitMobileTheme {
-        Surface {
-            SessionRunningNominalContent(
-                uiArrangement = UiArrangement.HORIZONTAL,
-                viewState = viewState,
-            )
-        }
-    }
-}
-
-@Preview(
-    showSystemUi = true,
-    device = "spec:parent=pixel_4,orientation=landscape",
-    uiMode = Configuration.UI_MODE_NIGHT_NO,
-    heightDp = 400,
-)
-@Preview(
-    showSystemUi = true,
-    device = "spec:parent=pixel_4,orientation=landscape",
-    uiMode = Configuration.UI_MODE_NIGHT_YES,
-    heightDp = 400,
-)
-@Composable
-private fun SessionRunningNominalContentPreviewPhoneLandscape(
-    @PreviewParameter(SessionRunningNominalContentPreviewParameterProvider::class) viewState: SessionViewState.RunningNominal,
-) {
-    SimpleHiitMobileTheme {
-        Surface {
-            SessionRunningNominalContent(
-                uiArrangement = UiArrangement.HORIZONTAL,
                 viewState = viewState,
             )
         }

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/di/SessionModule.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/di/SessionModule.kt
@@ -1,15 +1,32 @@
 package fr.shiningcat.simplehiit.android.mobile.ui.session.di
 
-import dagger.Binds
+import android.content.Context
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
 import fr.shiningcat.simplehiit.android.mobile.ui.session.SessionInteractor
 import fr.shiningcat.simplehiit.android.mobile.ui.session.SessionInteractorImpl
+import fr.shiningcat.simplehiit.commonresources.R
+import fr.shiningcat.simplehiit.domain.common.models.DurationStringFormatter
 
 @Module
 @InstallIn(ViewModelComponent::class)
-interface SessionModule {
-    @Binds
-    fun bindSessionInteractor(sessionInteractor: SessionInteractorImpl): SessionInteractor
+object SessionModule {
+    @Provides
+    fun provideSessionInteractor(sessionInteractor: SessionInteractorImpl): SessionInteractor = sessionInteractor
+
+    @Provides
+    fun provideDurationStringFormatter(
+        @ApplicationContext context: Context,
+    ): DurationStringFormatter =
+        DurationStringFormatter(
+            hoursMinutesSeconds = context.getString(R.string.hours_minutes_seconds_short),
+            hoursMinutesNoSeconds = context.getString(R.string.hours_minutes_no_seconds_short),
+            hoursNoMinutesNoSeconds = context.getString(R.string.hours_no_minutes_no_seconds_short),
+            minutesSeconds = context.getString(R.string.minutes_seconds_short),
+            minutesNoSeconds = context.getString(R.string.minutes_no_seconds_short),
+            seconds = context.getString(R.string.seconds_short),
+        )
 }

--- a/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/di/SessionModule.kt
+++ b/android/mobile/ui/session/src/main/java/fr/shiningcat/simplehiit/android/mobile/ui/session/di/SessionModule.kt
@@ -1,11 +1,15 @@
 package fr.shiningcat.simplehiit.android.mobile.ui.session.di
 
 import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioManager
+import android.media.SoundPool
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.scopes.ViewModelScoped
 import fr.shiningcat.simplehiit.android.mobile.ui.session.SessionInteractor
 import fr.shiningcat.simplehiit.android.mobile.ui.session.SessionInteractorImpl
 import fr.shiningcat.simplehiit.commonresources.R
@@ -29,4 +33,20 @@ object SessionModule {
             minutesNoSeconds = context.getString(R.string.minutes_no_seconds_short),
             seconds = context.getString(R.string.seconds_short),
         )
+
+    @Provides
+    @ViewModelScoped
+    fun provideSoundPool(): SoundPool =
+        SoundPool
+            .Builder()
+            .setMaxStreams(1)
+            .setAudioAttributes(
+                AudioAttributes
+                    .Builder()
+                    .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                    .setUsage(AudioAttributes.USAGE_GAME)
+                    .setFlags(AudioAttributes.FLAG_AUDIBILITY_ENFORCED)
+                    .setLegacyStreamType(AudioManager.STREAM_MUSIC)
+                    .build(),
+            ).build()
 }

--- a/android/mobile/ui/session/src/test/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionViewStateMapperTest.kt
+++ b/android/mobile/ui/session/src/test/java/fr/shiningcat/simplehiit/android/mobile/ui/session/SessionViewStateMapperTest.kt
@@ -27,15 +27,7 @@ import java.util.stream.Stream
 internal class SessionViewStateMapperTest : AbstractMockkTest() {
     private val mockFormatLongDurationMsAsSmallestHhMmSsStringUseCase =
         mockk<FormatLongDurationMsAsSmallestHhMmSsStringUseCase>()
-    private val durationStringFormatter =
-        DurationStringFormatter(
-            hoursMinutesSeconds = "",
-            hoursMinutesNoSeconds = "",
-            hoursNoMinutesNoSeconds = "",
-            minutesSeconds = "",
-            minutesNoSeconds = "",
-            seconds = "",
-        )
+    private val durationStringFormatter = DurationStringFormatter()
 
     @BeforeEach
     fun setUpMock() {

--- a/commonResources/src/main/res/values/strings.xml
+++ b/commonResources/src/main/res/values/strings.xml
@@ -100,8 +100,8 @@
     <string name="statistics_page_title">Statistics</string> <!-- insert user's name -->
     <string name="statistics_page_title_with_user_name">%1$s\'s statistics</string> <!-- insert user's name -->
     <plurals name="statistics_number_of_days">
-        <item quantity="one">%1$d day</item>
-        <item quantity="other">%1$d days</item>
+        <item quantity="one">%1$d\u00A0day</item>
+        <item quantity="other">%1$d\u00A0days</item>
     </plurals>
     <string name="statistics_page_switch_user">Switch user</string>
     <string name="sessions_total">sessions</string>
@@ -130,10 +130,10 @@
     <string name="exercise_type_lying">Lying</string>
 
     <!-- DURATION DISPLAY FORMATTING STRINGS-->
-    <string name="hours_minutes_seconds_short">%1$dh %2$02dmn %3$02ds</string>
-    <string name="hours_minutes_no_seconds_short">%1$dh %2$02dmn</string>
+    <string name="hours_minutes_seconds_short">%1$dh\u00A0%2$02dmn\u00A0%3$02ds</string>
+    <string name="hours_minutes_no_seconds_short">%1$dh\u00A0%2$02dmn</string>
     <string name="hours_no_minutes_no_seconds_short">%1$dh</string>
-    <string name="minutes_seconds_short">%1$dmn %2$02ds</string>
+    <string name="minutes_seconds_short">%1$dmn\u00A0%2$02ds</string>
     <string name="minutes_no_seconds_short">%1$dmn</string>
     <string name="seconds_short">%ds</string>
 

--- a/domain/common/src/main/java/fr/shiningcat/simplehiit/domain/common/models/DurationStringFormatter.kt
+++ b/domain/common/src/main/java/fr/shiningcat/simplehiit/domain/common/models/DurationStringFormatter.kt
@@ -4,10 +4,10 @@ import fr.shiningcat.simplehiit.commonutils.annotations.ExcludeFromJacocoGenerat
 
 @ExcludeFromJacocoGeneratedReport
 data class DurationStringFormatter(
-    val hoursMinutesSeconds: String = "%1\$02d:%2\$02d:%3\$02d",
+    val hoursMinutesSeconds: String = "%1$02d:%2$02d:%3$02d",
     val hoursMinutesNoSeconds: String = hoursMinutesSeconds,
     val hoursNoMinutesNoSeconds: String = hoursMinutesSeconds,
-    val minutesSeconds: String = "%1\$02d:%2\$02d",
+    val minutesSeconds: String = "%1$02d:%2$02d",
     val minutesNoSeconds: String = minutesSeconds,
     val seconds: String = "%02d",
 )

--- a/domain/common/src/test/java/fr/shiningcat/simplehiit/domain/common/usecases/FormatLongDurationMsAsSmallestHhMmSsStringUseCaseTest.kt
+++ b/domain/common/src/test/java/fr/shiningcat/simplehiit/domain/common/usecases/FormatLongDurationMsAsSmallestHhMmSsStringUseCaseTest.kt
@@ -29,10 +29,10 @@ internal class FormatLongDurationMsAsSmallestHhMmSsStringUseCaseTest : AbstractM
     ) {
         val durationsFormatter =
             DurationStringFormatter(
-                hoursMinutesSeconds = "%1\$dh %2$02dmn %3$02ds",
-                hoursMinutesNoSeconds = "%1\$dh %2$02dmn",
+                hoursMinutesSeconds = "%1\$dh\u00A0%2$02dmn\u00A0%3$02ds",
+                hoursMinutesNoSeconds = "%1\$dh\u00A0%2$02dmn",
                 hoursNoMinutesNoSeconds = "%1\$dh",
-                minutesSeconds = "%1\$dmn %2\$02ds",
+                minutesSeconds = "%1\$dmn\u00A0%2\$02ds",
                 minutesNoSeconds = "%1\$dmn",
                 seconds = "%ds",
             )
@@ -71,15 +71,15 @@ internal class FormatLongDurationMsAsSmallestHhMmSsStringUseCaseTest : AbstractM
                 Arguments.of(32000L, "32s"),
                 Arguments.of(180000L, "3mn"),
                 Arguments.of(780000L, "13mn"),
-                Arguments.of(124000L, "2mn 04s"),
-                Arguments.of(103000L, "1mn 43s"),
+                Arguments.of(124000L, "2mn\u00A004s"),
+                Arguments.of(103000L, "1mn\u00A043s"),
                 Arguments.of(3600000L, "1h"),
                 Arguments.of(57600000L, "16h"),
-                Arguments.of(46825000L, "13h 00mn 25s"),
-                Arguments.of(7380000L, "2h 03mn"),
-                Arguments.of(13500000L, "3h 45mn"),
-                Arguments.of(11045000L, "3h 04mn 05s"),
-                Arguments.of(443096000L, "123h 04mn 56s"),
+                Arguments.of(46825000L, "13h\u00A000mn\u00A025s"),
+                Arguments.of(7380000L, "2h\u00A003mn"),
+                Arguments.of(13500000L, "3h\u00A045mn"),
+                Arguments.of(11045000L, "3h\u00A004mn\u00A005s"),
+                Arguments.of(443096000L, "123h\u00A004mn\u00A056s"),
             )
     }
 }


### PR DESCRIPTION
extracted durationscreenformatter to inject it directly into session viewmodel
removed init public method from session viewmodel
extracted the SoundPool creation from the viewmodel to have it injected instead
preloading the beep sound has been streamlined
switched mobile session screen previews to use the new multi preview annotations
split session screen preview out of main file
new AccessibilityHelper to adapt dp to fontscale
tweaked CountDownComponent to adapt to fontscale
tweaked duration format strings to use unbreakable spaces, adapted tests
new multi preview for all composables