### PR TITLE
auto-merge will now use a PAT to allow it to trigger other workflows …

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -120,6 +120,7 @@ jobs:
         if: steps.pr.outputs.number && steps.checks.outputs.ready == 'true'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.AUTO_MERGE_PAT }}
           script: |
             const prNumber = ${{ steps.pr.outputs.number }};
             


### PR DESCRIPTION
…(github safety lock)