### PR TITLE
updated dependencies

### DIFF
--- a/.github/workflows/reusable-dependency-updates-checker.yml
+++ b/.github/workflows/reusable-dependency-updates-checker.yml
@@ -55,8 +55,10 @@ jobs:
           
           # Extract only the "dependencies have later" section and filter out transitive dependencies
           # Also filter out the URL lines that follow each filtered dependency
-          sed -n '/The following dependencies have later/,/^Failed to determine\|^Gradle\|^$/p' dependency-updates-output.txt | \
-            grep -v '^Failed to determine\|^Gradle' | \
+          # Filter out unstable Gradle versions (RC, canary, milestone, alpha, beta, dev, SNAPSHOT)
+          sed -n '/The following dependencies have later/,/^Failed to determine\|^$/p' dependency-updates-output.txt | \
+            grep -v '^Failed to determine' | \
+            grep -E -v 'Gradle.*(-rc-|-canary|-milestone|-alpha|-beta|-dev|RC|SNAPSHOT)' | \
             grep -F -v 'com.pinterest.ktlint:ktlint-cli' | \
             grep -F -v 'com.pinterest.ktlint:ktlint-cli-reporter-baseline' | \
             grep -F -v 'com.pinterest.ktlint:ktlint-ruleset-standard' | \
@@ -64,7 +66,6 @@ jobs:
             grep -F -v 'io.github.oshai:kotlin-logging' | \
             grep -F -v 'org.jacoco:org.jacoco.ant' | \
             grep -F -v 'org.jetbrains.kotlin:kotlin-test' | \
-            grep -F -v 'Gradle:' | \
             grep -F -v 'https://github.com/pinterest/ktlint' | \
             grep -F -v 'https://detekt.github.io/detekt' | \
             grep -F -v 'https://github.com/oshai/kotlin-logging' > dependency-updates-filtered.txt || true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,16 +6,15 @@ ksp = "2.3.4"
 kover = "0.9.4"
 
 # Code Quality & Analysis
-ktlintComposeRuleset = "0.5.2"
+ktlintComposeRuleset = "0.5.3"
 ktlintGradlePlugin = "14.0.1"
 dependencyUpdatePlugin = "0.53.0"
 modulesGraphAssert = "2.9.0"
-develocity = "4.3"
 
 # Dependency Injection
-koin = "4.0.0"
-koinAndroidxCompose = "4.0.0"
-koinTest = "4.0.0"
+koin = "4.1.1"
+koinAndroidxCompose = "4.1.1"
+koinTest = "4.1.1"
 
 # Database
 room = "2.8.4"
@@ -23,7 +22,7 @@ room = "2.8.4"
 # Testing
 mockk = "1.14.7"
 junit = "1.3.0"
-jupiter = "6.0.1"
+jupiter = "6.0.2"
 testRunner = "1.7.0"
 archCoreTest = "2.2.0"
 jetBrainsCoroutinesTest = "1.10.2"
@@ -124,7 +123,6 @@ ktlint-gradle = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGra
 dependencyupdate = { id = "com.github.ben-manes.versions", version.ref = "dependencyUpdatePlugin" }
 modules-graph-assert = { id = "com.jraska.module.graph.assertion", version.ref = "modulesGraphAssert" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
-develocity = { id = "com.gradle.develocity", version.ref = "develocity" }
 
 # Convention Plugins - Android Application
 simplehiit-android-application-handheld = { id = "fr.shiningcat.simplehiit.android.application.handheld" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,8 @@ pluginManagement {
 }
 
 plugins {
-    id("com.gradle.develocity") version "3.18.2"
+    // NOTE: Version catalog (libs) is not available in settings.gradle.kts
+    id("com.gradle.develocity") version "4.3"
 }
 
 develocity {


### PR DESCRIPTION
removed develocity redundant declaration in the toml: it's not available to the settings.gradle.kts file, where it has to be hardcoded. Also tweaked filtering of report for ci when running dependencies update