### PR TITLE
Release v1.02

### DIFF
--- a/build-logic/convention/src/main/kotlin/fr/shiningcat/simplehiit/config/Config.kt
+++ b/build-logic/convention/src/main/kotlin/fr/shiningcat/simplehiit/config/Config.kt
@@ -28,8 +28,8 @@ object ConfigHandheld {
             targetSdkVersion = 36,
             compileSdkVersion = 36,
             applicationId = APPLICATION_ID,
-            versionCode = 23100101,
-            versionName = "1.01",
+            versionCode = 23100102,
+            versionName = "1.02",
             nameSpace = "fr.shiningcat.simplehiit.mobile.app",
         )
     val jvm =
@@ -46,8 +46,8 @@ object ConfigTv {
             targetSdkVersion = 36,
             compileSdkVersion = 36,
             applicationId = APPLICATION_ID,
-            versionCode = 23100101,
-            versionName = "1.01",
+            versionCode = 23010102,
+            versionName = "1.02",
             nameSpace = "fr.shiningcat.simplehiit.tv.app",
         )
     val jvm =

--- a/fastlane/metadata/android/en-US/changelogs/23100102.txt
+++ b/fastlane/metadata/android/en-US/changelogs/23100102.txt
@@ -1,0 +1,6 @@
+Version 1.02
+
+- Fix session restart on orientation change (#333)
+- Improve session timer visibility and layout (fixes #325)
+- Increase visibility of REST step type for clarity
+- Update dependencies, and gradle version bumped to 9


### PR DESCRIPTION
## Summary
- Bump version to 1.02 (mobile + TV)
- F-Droid changelog for versionCode 23100102

## Changes included in this release
- Fix session restart on orientation change (#333)
- Improve session timer visibility and layout (#325)
- Upgrade to AGP 9.1.0, Gradle 9.3.1
- Dependencies update (#324)
- F-Droid badge update (#329)