### PR TITLE
Update dependencies (issue #339 + additional)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Build Tools & Plugins
 agp = "9.1.0"
-kgp = "2.3.20"
+kgp = "2.3.21"
 ksp = "2.3.6"
 kover = "0.9.8"
 
@@ -12,9 +12,9 @@ dependencyUpdatePlugin = "0.53.0"
 modulesGraphAssert = "2.9.0"
 
 # Dependency Injection
-koin = "4.2.0"
-koinAndroidxCompose = "4.2.0"
-koinTest = "4.2.0"
+koin = "4.2.1"
+koinAndroidxCompose = "4.2.1"
+koinTest = "4.2.1"
 
 # Database
 room = "2.8.4"
@@ -36,8 +36,8 @@ lifecycleProcess = "2.10.0"
 composeBom = "2026.03.01"
 navigation3 = "1.0.1"
 activityCompose = "1.13.0"
-kotlinSerialization = "2.3.20"
-kotlinxSerializationCore = "1.10.0"
+kotlinSerialization = "2.3.21"
+kotlinxSerializationCore = "1.11.0"
 
 # TV-specific
 # see https://developer.android.com/jetpack/androidx/releases/tv

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,18 +3,18 @@
 agp = "9.1.0"
 kgp = "2.3.20"
 ksp = "2.3.6"
-kover = "0.9.7"
+kover = "0.9.8"
 
 # Code Quality & Analysis
 ktlintGradlePlugin = "14.2.0"
-spotless = "8.3.0"
+spotless = "8.4.0"
 dependencyUpdatePlugin = "0.53.0"
 modulesGraphAssert = "2.9.0"
 
 # Dependency Injection
-koin = "4.1.1"
-koinAndroidxCompose = "4.1.1"
-koinTest = "4.1.1"
+koin = "4.2.0"
+koinAndroidxCompose = "4.2.0"
+koinTest = "4.2.0"
 
 # Database
 room = "2.8.4"
@@ -33,7 +33,7 @@ datastore = "1.2.1"
 lifecycleProcess = "2.10.0"
 
 # Compose Ecosystem
-composeBom = "2026.03.00"
+composeBom = "2026.03.01"
 navigation3 = "1.0.1"
 activityCompose = "1.13.0"
 kotlinSerialization = "2.3.20"


### PR DESCRIPTION
## Summary
- Compose BOM: 2026.03.00 → 2026.03.01 (foundation, ui-tooling, ui-test-manifest, ui-tooling-preview)
- Koin (all artifacts): 4.1.1 → 4.2.1
- Spotless: 8.3.0 → 8.4.0
- Kover: 0.9.7 → 0.9.8
- Kotlin (KGP + plugins): 2.3.20 → 2.3.21
- kotlinx-serialization-core: 1.10.0 → 1.11.0

Covers all 13 updates from #339 plus additional updates discovered by running dependencyUpdates.

Note: Koin 4.2.0/4.2.1 does NOT fix issue #2235 (ViewModel clearing on Navigation3 entry pop). Our rememberViewModelStoreNavEntryDecorator() workaround remains necessary.

Closes #339

## Test plan
- [x] assembleDebug passes (mobile + TV)
- [x] All unit tests pass
- [x] Manual device testing (user verified)