### PR TITLE
Release v1.03

### DIFF
--- a/build-logic/convention/src/main/kotlin/fr/shiningcat/simplehiit/config/Config.kt
+++ b/build-logic/convention/src/main/kotlin/fr/shiningcat/simplehiit/config/Config.kt
@@ -28,8 +28,8 @@ object ConfigHandheld {
             targetSdkVersion = 36,
             compileSdkVersion = 36,
             applicationId = APPLICATION_ID,
-            versionCode = 23100102,
-            versionName = "1.02",
+            versionCode = 23100103,
+            versionName = "1.03",
             nameSpace = "fr.shiningcat.simplehiit.mobile.app",
         )
     val jvm =
@@ -46,8 +46,8 @@ object ConfigTv {
             targetSdkVersion = 36,
             compileSdkVersion = 36,
             applicationId = APPLICATION_ID,
-            versionCode = 23010102,
-            versionName = "1.02",
+            versionCode = 23010103,
+            versionName = "1.03",
             nameSpace = "fr.shiningcat.simplehiit.tv.app",
         )
     val jvm =

--- a/fastlane/metadata/android/en-US/changelogs/23100103.txt
+++ b/fastlane/metadata/android/en-US/changelogs/23100103.txt
@@ -1,0 +1,4 @@
+Version 1.03
+
+- Add beep sound type selector in settings (#341)
+- Fix session showing stale state after abort and relaunch (#342)


### PR DESCRIPTION
## Summary
Version bump to 1.03.

### Changes since v1.02
- Add beep sound type selector in settings (#341)
- Fix session showing stale state after abort and relaunch (#342)
- Dependency updates (#343, #344)

## Test plan
- [x] Build passes
- [x] All unit tests pass
- [x] Device tested (mobile)