### PR TITLE
Monthly dependency updates — July 2026

### DIFF
--- a/build-logic/convention/src/main/kotlin/fr/shiningcat/simplehiit/config/Config.kt
+++ b/build-logic/convention/src/main/kotlin/fr/shiningcat/simplehiit/config/Config.kt
@@ -26,7 +26,7 @@ object ConfigHandheld {
         AndroidConfig(
             minSdkVersion = 23,
             targetSdkVersion = 36,
-            compileSdkVersion = 36,
+            compileSdkVersion = 37,
             applicationId = APPLICATION_ID,
             versionCode = 23100103,
             versionName = "1.03",
@@ -44,7 +44,7 @@ object ConfigTv {
         AndroidConfig(
             minSdkVersion = 23,
             targetSdkVersion = 36,
-            compileSdkVersion = 36,
+            compileSdkVersion = 37,
             applicationId = APPLICATION_ID,
             versionCode = 23010103,
             versionName = "1.03",
@@ -62,7 +62,7 @@ object ConfigLibrary {
     val config =
         AndroidLibraryConfig(
             minSdkVersion = 23,
-            compileSdkVersion = 36,
+            compileSdkVersion = 37,
         )
     val jvm =
         JvmConfig(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,27 +1,27 @@
 [versions]
 # Build Tools & Plugins
 agp = "9.2.1"
-kgp = "2.3.21"
-ksp = "2.3.9"
+kgp = "2.4.0"
+ksp = "2.3.10"
 kover = "0.9.8"
 
 # Code Quality & Analysis
 ktlintGradlePlugin = "14.2.0"
-spotless = "8.6.0"
+spotless = "8.8.0"
 dependencyUpdatePlugin = "0.54.0"
 modulesGraphAssert = "2.9.1"
 
 # Dependency Injection
-koin = "4.2.1"
-koinAndroidxCompose = "4.2.1"
-koinTest = "4.2.1"
+koin = "4.2.2"
+koinAndroidxCompose = "4.2.2"
+koinTest = "4.2.2"
 
 # Database
 room = "2.8.4"
 
 # Testing
 mockk = "1.14.11"
-jupiter = "6.1.0"
+jupiter = "6.1.1"
 testRunner = "1.7.0"
 testExtJunit = "1.3.0"
 jetBrainsCoroutinesTest = "1.11.0"
@@ -30,13 +30,13 @@ jetBrainsCoroutinesTest = "1.11.0"
 appCompat = "1.7.1"
 datastore = "1.2.1"
 # see https://developer.android.com/jetpack/androidx/releases/lifecycle
-lifecycleProcess = "2.10.0"
+lifecycleProcess = "2.11.0"
 
 # Compose Ecosystem
-composeBom = "2026.05.01"
-navigation3 = "1.1.2"
+composeBom = "2026.06.00"
+navigation3 = "1.1.3"
 activityCompose = "1.13.0"
-kotlinSerialization = "2.3.21"
+kotlinSerialization = "2.4.0"
 kotlinxSerializationCore = "1.11.0"
 
 # TV-specific


### PR DESCRIPTION
Closes #350 — July 2026 dependency batch (25 flagged updates + KSP alignment).

## Updates
- **Kotlin** 2.3.21 → 2.4.0 (kgp, stdlib, build-tools-compat, compose + serialization plugins)
- **KSP** 2.3.9 → 2.3.10 — *not in the dep-check list; bumped manually.* 2.3.10 carries the Kotlin 2.4.0 compat fix (default module-name sanitisation). KSP2 versioning is decoupled from the exact Kotlin version, so no `2.4.0-*` release is needed.
- **kotlin-serialization** plugin 2.3.21 → 2.4.0
- **Compose BOM** 2026.05.01 → 2026.06.00 (covers foundation / ui-tooling / ui-test-manifest / ui-tooling-preview 1.11.3 transitively)
- **Koin** 4.2.1 → 4.2.2 (core, android, compose, compose-navigation, test, test-junit4)
- **Navigation3** 1.1.2 → 1.1.3
- **Lifecycle** 2.10.0 → 2.11.0
- **Spotless** 8.6.0 → 8.8.0
- **JUnit Jupiter** 6.1.0 → 6.1.1 (platform-launcher bumps transitively)

## compileSdk 36 → 37
Lifecycle 2.11.0 requires compileSdk 37 (AAR metadata check). Bumped `compileSdkVersion` 36→37 in all three `Config.kt` blocks (mobile / TV / library). **targetSdk stays 36** — compiling against newer APIs without opting into new runtime behaviour.

## Notes
- Compiles clean against Kotlin 2.4.0; mobile + TV builds verified.
- This is a major Kotlin/AGP-adjacent bump — a `./gradlew clean build` is needed after checkout (incremental state is invalidated; the TV build in particular).