### PR TITLE
Clear nav back stack when switching to top-level destinations

### DIFF
--- a/android/mobile/app/src/main/java/fr/shiningcat/simplehiit/android/mobile/app/SimpleHiitNavigation.kt
+++ b/android/mobile/app/src/main/java/fr/shiningcat/simplehiit/android/mobile/app/SimpleHiitNavigation.kt
@@ -31,10 +31,12 @@ fun SimpleHiitNavigation(
     // Home, so it is pushed onto the stack and can be backed out of.
     val navigate: (Screen) -> Unit = { destination ->
         when (destination) {
-            Screen.Home, Screen.Settings, Screen.Statistics, Screen.About ->
+            Screen.Home, Screen.Settings, Screen.Statistics, Screen.About -> {
                 navigationViewModel.clearAndNavigateTo(destination)
-            Screen.Session ->
+            }
+            Screen.Session -> {
                 navigationViewModel.navigateTo(destination)
+            }
         }
     }
     NavDisplay(

--- a/android/mobile/app/src/main/java/fr/shiningcat/simplehiit/android/mobile/app/SimpleHiitNavigation.kt
+++ b/android/mobile/app/src/main/java/fr/shiningcat/simplehiit/android/mobile/app/SimpleHiitNavigation.kt
@@ -26,6 +26,17 @@ fun SimpleHiitNavigation(
     hiitLogger: HiitLogger,
     navigationViewModel: NavigationViewModel = koinViewModel(),
 ) {
+    // Top-level destinations (reachable from the navigation sidebar) reset the back stack:
+    // switching between them is flat navigation, not a push. Session is a flow entered from
+    // Home, so it is pushed onto the stack and can be backed out of.
+    val navigate: (Screen) -> Unit = { destination ->
+        when (destination) {
+            Screen.Home, Screen.Settings, Screen.Statistics, Screen.About ->
+                navigationViewModel.clearAndNavigateTo(destination)
+            Screen.Session ->
+                navigationViewModel.navigateTo(destination)
+        }
+    }
     NavDisplay(
         backStack = navigationViewModel.backStack,
         onBack = { navigationViewModel.goBack() },
@@ -38,21 +49,21 @@ fun SimpleHiitNavigation(
             entryProvider {
                 entry<Screen.Home> {
                     HomeScreen(
-                        navigateTo = navigationViewModel::navigateTo,
+                        navigateTo = navigate,
                         uiArrangement = uiArrangement,
                         hiitLogger = hiitLogger,
                     )
                 }
                 entry<Screen.Settings> {
                     SettingsScreen(
-                        navigateTo = navigationViewModel::navigateTo,
+                        navigateTo = navigate,
                         uiArrangement = uiArrangement,
                         hiitLogger = hiitLogger,
                     )
                 }
                 entry<Screen.Statistics> {
                     StatisticsScreen(
-                        navigateTo = navigationViewModel::navigateTo,
+                        navigateTo = navigate,
                         uiArrangement = uiArrangement,
                         hiitLogger = hiitLogger,
                     )
@@ -66,7 +77,7 @@ fun SimpleHiitNavigation(
                 }
                 entry<Screen.About> {
                     AboutScreen(
-                        navigateTo = navigationViewModel::navigateTo,
+                        navigateTo = navigate,
                         uiArrangement = uiArrangement,
                     )
                 }

--- a/android/shared/core/src/test/java/fr/shiningcat/simplehiit/android/shared/core/NavigationViewModelTest.kt
+++ b/android/shared/core/src/test/java/fr/shiningcat/simplehiit/android/shared/core/NavigationViewModelTest.kt
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: 2024-2026 shining-cat
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+package fr.shiningcat.simplehiit.android.shared.core
+
+import fr.shiningcat.simplehiit.testutils.AbstractMockkTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class NavigationViewModelTest : AbstractMockkTest() {
+    private fun buildViewModel() = NavigationViewModel(hiitLogger = mockHiitLogger)
+
+    @Test
+    fun `initial back stack contains only Home`() {
+        val viewModel = buildViewModel()
+        assertEquals(listOf(Screen.Home), viewModel.backStack.toList())
+    }
+
+    @Test
+    fun `navigateTo pushes destination onto the back stack`() {
+        val viewModel = buildViewModel()
+
+        viewModel.navigateTo(Screen.Session)
+
+        assertEquals(listOf(Screen.Home, Screen.Session), viewModel.backStack.toList())
+    }
+
+    @Test
+    fun `clearAndNavigateTo resets the back stack to the single destination`() {
+        val viewModel = buildViewModel()
+        viewModel.navigateTo(Screen.Session)
+
+        viewModel.clearAndNavigateTo(Screen.Settings)
+
+        assertEquals(listOf(Screen.Settings), viewModel.backStack.toList())
+    }
+
+    @Test
+    fun `goBack removes the last entry and returns true when not at root`() {
+        val viewModel = buildViewModel()
+        viewModel.navigateTo(Screen.Session)
+
+        val result = viewModel.goBack()
+
+        assertTrue(result)
+        assertEquals(listOf(Screen.Home), viewModel.backStack.toList())
+    }
+
+    @Test
+    fun `goBack returns false and keeps root when already at root`() {
+        val viewModel = buildViewModel()
+
+        val result = viewModel.goBack()
+
+        assertFalse(result)
+        assertEquals(listOf(Screen.Home), viewModel.backStack.toList())
+    }
+}

--- a/android/tv/app/src/main/java/fr/shiningcat/simplehiit/android/tv/app/SimpleHiitNavigation.kt
+++ b/android/tv/app/src/main/java/fr/shiningcat/simplehiit/android/tv/app/SimpleHiitNavigation.kt
@@ -26,6 +26,17 @@ fun SimpleHiitNavigation(
     hiitLogger: HiitLogger,
     navigationViewModel: NavigationViewModel = koinViewModel(),
 ) {
+    // Top-level destinations (reachable from the navigation sidebar) reset the back stack:
+    // switching between them is flat navigation, not a push. Session is a flow entered from
+    // Home, so it is pushed onto the stack and can be backed out of.
+    val navigate: (Screen) -> Unit = { destination ->
+        when (destination) {
+            Screen.Home, Screen.Settings, Screen.Statistics, Screen.About ->
+                navigationViewModel.clearAndNavigateTo(destination)
+            Screen.Session ->
+                navigationViewModel.navigateTo(destination)
+        }
+    }
     NavDisplay(
         backStack = navigationViewModel.backStack,
         onBack = { navigationViewModel.goBack() },
@@ -38,19 +49,19 @@ fun SimpleHiitNavigation(
             entryProvider {
                 entry<Screen.Home> {
                     HomeScreen(
-                        navigateTo = navigationViewModel::navigateTo,
+                        navigateTo = navigate,
                         hiitLogger = hiitLogger,
                     )
                 }
                 entry<Screen.Settings> {
                     SettingsScreen(
-                        navigateTo = navigationViewModel::navigateTo,
+                        navigateTo = navigate,
                         hiitLogger = hiitLogger,
                     )
                 }
                 entry<Screen.Statistics> {
                     StatisticsScreen(
-                        navigateTo = navigationViewModel::navigateTo,
+                        navigateTo = navigate,
                         hiitLogger = hiitLogger,
                     )
                 }
@@ -62,7 +73,7 @@ fun SimpleHiitNavigation(
                 }
                 entry<Screen.About> {
                     AboutScreen(
-                        navigateTo = navigationViewModel::navigateTo,
+                        navigateTo = navigate,
                     )
                 }
             },

--- a/android/tv/app/src/main/java/fr/shiningcat/simplehiit/android/tv/app/SimpleHiitNavigation.kt
+++ b/android/tv/app/src/main/java/fr/shiningcat/simplehiit/android/tv/app/SimpleHiitNavigation.kt
@@ -31,10 +31,12 @@ fun SimpleHiitNavigation(
     // Home, so it is pushed onto the stack and can be backed out of.
     val navigate: (Screen) -> Unit = { destination ->
         when (destination) {
-            Screen.Home, Screen.Settings, Screen.Statistics, Screen.About ->
+            Screen.Home, Screen.Settings, Screen.Statistics, Screen.About -> {
                 navigationViewModel.clearAndNavigateTo(destination)
-            Screen.Session ->
+            }
+            Screen.Session -> {
                 navigationViewModel.navigateTo(destination)
+            }
         }
     }
     NavDisplay(


### PR DESCRIPTION
Closes #352.

## Problem
`NavigationViewModel.clearAndNavigateTo()` was dead code — every navigation went through `navigateTo()` (append-only), so switching between top-level destinations via the sidebar accumulated a back stack instead of behaving as flat navigation.

## Fix
Route navigation policy at the app wiring layer (`SimpleHiitNavigation.kt`, mobile + TV) rather than special-casing inside `navigateTo`:

```kotlin
val navigate: (Screen) -> Unit = { destination ->
    when (destination) {
        Screen.Home, Screen.Settings, Screen.Statistics, Screen.About ->
            navigationViewModel.clearAndNavigateTo(destination)
        Screen.Session ->
            navigationViewModel.navigateTo(destination)
    }
}
```

- Top-level destinations (sidebar tabs) reset the stack → flat side-nav.
- Session stays a pushed flow entered from Home (can be backed out of).
- Exhaustive `when` over the sealed `Screen` — a new screen forces an explicit push/reset decision.
- `NavigationViewModel`/VM primitives stay clean; policy lives in the composition layer.

## Tests
Adds `NavigationViewModelTest` (5 cases): initial stack, `navigateTo` push, `clearAndNavigateTo` reset, `goBack` at/above root.

## Behaviour note
Back from a non-Home top-level tab now exits (flat model) rather than returning through prior tabs — intended per the flat side-nav decision.