### PR TITLE
Release v1.04

### DIFF
--- a/build-logic/convention/src/main/kotlin/fr/shiningcat/simplehiit/config/Config.kt
+++ b/build-logic/convention/src/main/kotlin/fr/shiningcat/simplehiit/config/Config.kt
@@ -28,8 +28,8 @@ object ConfigHandheld {
             targetSdkVersion = 36,
             compileSdkVersion = 37,
             applicationId = APPLICATION_ID,
-            versionCode = 23100103,
-            versionName = "1.03",
+            versionCode = 23100104,
+            versionName = "1.04",
             nameSpace = "fr.shiningcat.simplehiit.mobile.app",
         )
     val jvm =
@@ -46,8 +46,8 @@ object ConfigTv {
             targetSdkVersion = 36,
             compileSdkVersion = 37,
             applicationId = APPLICATION_ID,
-            versionCode = 23010103,
-            versionName = "1.03",
+            versionCode = 23010104,
+            versionName = "1.04",
             nameSpace = "fr.shiningcat.simplehiit.tv.app",
         )
     val jvm =

--- a/fastlane/metadata/android/en-US/changelogs/23100104.txt
+++ b/fastlane/metadata/android/en-US/changelogs/23100104.txt
@@ -1,0 +1,5 @@
+Version 1.04
+
+- Add workout progress indicator showing your period and cycle during a session, so you don't lose track in long or custom workouts, with screen reader support (#347)
+- Fix navigation building up an unexpected back stack when switching between main screens (#353)
+- Update dependencies and build tooling


### PR DESCRIPTION
Release v1.04.

## Contents (since v1.03)
- Session period/cycle progress indicator with a11y (#354, closes #347)
- Navigation back-stack fix (#353)
- July + June dependency updates (#351, #348), Gradle daemon JDK 21 pin

## Release steps
- [x] Bump versionName/versionCode to 1.04 (handheld 23100104, tv 23010104)
- [x] F-Droid changelog (23100104.txt)
- [ ] Merge → tag v1.04 → CI release build