### PR TITLE
Apply monthly dependency updates (#357)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
 # Build Tools & Plugins
-agp = "9.2.1"
-kgp = "2.4.0"
+agp = "9.3.1"
+kgp = "2.4.10"
 ksp = "2.3.10"
-kover = "0.9.8"
+kover = "0.9.9"
 
 # Code Quality & Analysis
 ktlintGradlePlugin = "14.2.0"
-spotless = "8.8.0"
-dependencyUpdatePlugin = "0.54.0"
+spotless = "8.9.0"
+dependencyUpdatePlugin = "0.58.0"
 modulesGraphAssert = "2.9.1"
 
 # Dependency Injection
@@ -21,7 +21,7 @@ room = "2.8.4"
 
 # Testing
 mockk = "1.14.11"
-jupiter = "6.1.1"
+jupiter = "6.1.2"
 testRunner = "1.7.0"
 testExtJunit = "1.3.0"
 jetBrainsCoroutinesTest = "1.11.0"
@@ -33,10 +33,10 @@ datastore = "1.2.1"
 lifecycleProcess = "2.11.0"
 
 # Compose Ecosystem
-composeBom = "2026.06.00"
-navigation3 = "1.1.3"
+composeBom = "2026.06.01"
+navigation3 = "1.1.5"
 activityCompose = "1.13.0"
-kotlinSerialization = "2.4.0"
+kotlinSerialization = "2.4.10"
 kotlinxSerializationCore = "1.11.0"
 
 # TV-specific
@@ -46,7 +46,7 @@ tvFoundation = "1.0.0"
 
 # UI & Design
 material = "1.14.0"
-glide = "5.0.7"
+glide = "5.0.9"
 glideCompose = "1.0.0-beta09"
 
 [libraries]
@@ -117,7 +117,7 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 # Code Quality & Analysis Plugins
 ktlint-gradle = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradlePlugin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
-dependencyupdate = { id = "com.github.ben-manes.versions", version.ref = "dependencyUpdatePlugin" }
+dependencyupdate = { id = "io.github.ben-manes.versions", version.ref = "dependencyUpdatePlugin" }
 modules-graph-assert = { id = "com.jraska.module.graph.assertion", version.ref = "modulesGraphAssert" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Closes #357

Applies all 32 available updates from the monthly sanity check, mapped onto the version catalog (compose sub-artifacts follow the BOM; the `com.android.tools.*` cluster follows AGP; the `kotlin-*` cluster follows the Kotlin/serialization refs).

## Catalog bumps
- **AGP** 9.2.1 → 9.3.1
- **Kotlin (kgp + serialization)** 2.4.0 → 2.4.10
- **kover** 0.9.8 → 0.9.9
- **spotless** 8.8.0 → 8.9.0
- **ben-manes versions** 0.54.0 → 0.58.0 — plugin id migrated `com.github.ben-manes.versions` → `io.github.ben-manes.versions` (relocated in 0.58.0; the `DependencyUpdatesTask` class package is unchanged)
- **jupiter** 6.1.1 → 6.1.2 (junit-platform-launcher aligns transitively)
- **compose-bom** 2026.06.00 → 2026.06.01
- **navigation3** 1.1.3 → 1.1.5
- **glide** 5.0.7 → 5.0.9

## Gradle wrapper
- 9.4.1 → **9.5.0** — required: AGP 9.3.1 enforces a Gradle ≥ 9.5.0 floor.

## Notes
- KSP left at 2.3.10 (not flagged in #357); verified it compiles cleanly against Kotlin 2.4.10.
- `gradle.properties` intentionally excluded (unrelated local tweak).

## Verification
`./gradlew clean testDebugUnitTest assembleDebug spotlessCheck ktlintCheck --warning-mode all` → **BUILD SUCCESSFUL**, no new deprecations introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)